### PR TITLE
Allow for localization of the plugin.

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -6,6 +6,7 @@
  Author: wordpressdotorg
  Version: 0.9-alpha
  Author URI: https://wordpress.org/
+ Text Domain: debug-bar
  */
 
 /***
@@ -37,6 +38,8 @@ class Debug_Bar {
 			return;
 		}
 
+		load_plugin_textdomain( 'debug-bar' );
+
 		add_action( 'admin_bar_menu',               array( $this, 'admin_bar_menu' ), 1000 );
 		add_action( 'admin_footer',                 array( $this, 'render' ), 1000 );
 		add_action( 'wp_footer',                    array( $this, 'render' ), 1000 );
@@ -49,7 +52,8 @@ class Debug_Bar {
 		$this->init_panels();
 	}
 
-	/* Are we on the wp-login.php page?
+	/**
+	 * Are we on the wp-login.php page?
 	 * We can get here while logged in and break the page as the admin bar isn't shown and otherthings the js relies on aren't available.
 	 */
 	function is_wp_login() {
@@ -214,14 +218,37 @@ class Debug_Bar {
 		<div id="debug-status">
 			<?php //@todo: Add a links to information about WP_DEBUG, PHP version, MySQL version, and Peak Memory.
 			$statuses = array();
-			$statuses[] = array( 'site', php_uname( 'n' ), sprintf( __( '#%d', 'debug-bar' ), get_current_blog_id() ) );
-			$statuses[] = array( 'php', __('PHP', 'debug-bar'), phpversion() );
-			$db_title = empty( $wpdb->is_mysql ) ? __( 'DB', 'debug-bar' ) : 'MySQL';
-			$statuses[] = array( 'db', $db_title, $wpdb->db_version() );
-			$statuses[] = array( 'memory', __('Memory Usage', 'debug-bar'), sprintf( __('%s bytes', 'debug-bar'), number_format_i18n( $this->safe_memory_get_peak_usage() ) ) );
+			$statuses[] = array(
+				'site',
+				php_uname( 'n' ),
+				/* translators: %d is the site id number in a multi-site setting. */
+				sprintf( __( '#%d', 'debug-bar' ), get_current_blog_id() ),
+			);
+			$statuses[] = array(
+				'php',
+				__( 'PHP', 'debug-bar' ),
+				phpversion(),
+			);
+			$db_title = empty( $wpdb->is_mysql ) ? __( 'DB', 'debug-bar' ) : __( 'MySQL', 'debug-bar' );
+			$statuses[] = array(
+				'db',
+				$db_title,
+				$wpdb->db_version(),
+			);
+			$statuses[] = array(
+				'memory',
+				__( 'Memory Usage', 'debug-bar' ),
+				/* translators: %s is a formatted number representing the memory usage. */
+				sprintf( __( '%s bytes', 'debug-bar' ), number_format_i18n( $this->safe_memory_get_peak_usage() ) ),
+			);
 
-			if ( ! WP_DEBUG )
-				$statuses[] = array( 'warning', __('Please Enable', 'debug-bar'), 'WP_DEBUG' );
+			if ( ! WP_DEBUG ) {
+				$statuses[] = array(
+					'warning',
+					__( 'Please Enable', 'debug-bar' ),
+					'WP_DEBUG',
+				);
+			}
 
 			$statuses = apply_filters( 'debug_bar_statuses', $statuses );
 

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -28,9 +28,9 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 
 	function render() {
 		echo "<div id='debug-bar-deprecated'>";
-		echo '<h2><span>Total Functions:</span>' . number_format( count( $this->deprecated_functions ) ) . "</h2>\n";
-		echo '<h2><span>Total Arguments:</span>' . number_format( count( $this->deprecated_arguments ) ) . "</h2>\n";
-		echo '<h2><span>Total Files:</span>' . number_format( count( $this->deprecated_files ) ) . "</h2>\n";
+		echo '<h2><span>', __( 'Total Functions:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->deprecated_functions ) ), "</h2>\n";
+		echo '<h2><span>', __( 'Total Arguments:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->deprecated_arguments ) ), "</h2>\n";
+		echo '<h2><span>', __( 'Total Files:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->deprecated_files ) ), "</h2>\n";
 		if ( count( $this->deprecated_functions ) ) {
 			echo '<ol class="debug-bar-deprecated-list">';
 			foreach ( $this->deprecated_functions as $location => $message_stack) {
@@ -79,10 +79,13 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		}
 		$file = $backtrace[ $bt ]['file'];
 		$line = $backtrace[ $bt ]['line'];
-		if ( ! is_null($replacement) )
+		if ( ! is_null($replacement) ) {
+			/* translators: %1$s is a function or file name, %2$s a version number, %3$s an alternative function or file to use. */
 			$message = sprintf( __('%1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.', 'debug-bar'), $function, $version, $replacement );
-		else
+		} else {
+			/* translators: %1$s is a function or file name, %2$s a version number. */
 			$message = sprintf( __('%1$s is <strong>deprecated</strong> since version %2$s with no alternative available.', 'debug-bar'), $function, $version );
+		}
 
 		$this->deprecated_functions[$file.':'.$line] = array( $message, wp_debug_backtrace_summary( null, $bt ) );
 	}
@@ -93,10 +96,13 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		$file_abs = str_replace(ABSPATH, '', $file);
 		$line = $backtrace[4]['line'];
 		$message = empty( $message ) ? '' : ' ' . $message;
-		if ( ! is_null( $replacement ) )
+		if ( ! is_null( $replacement ) ) {
+			/* translators: %1$s is a function or file name, %2$s a version number, %3$s an alternative function or file to use. */
 			$message = sprintf( __('%1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.', 'debug-bar'), $file_abs, $version, $replacement ) . $message;
-		else
+		} else {
+			/* translators: %1$s is a function or file name, %2$s a version number. */
 			$message = sprintf( __('%1$s is <strong>deprecated</strong> since version %2$s with no alternative available.', 'debug-bar'), $file_abs, $version ) . $message;
+		}
 
 		$this->deprecated_files[$file.':'.$line] = array( $message, wp_debug_backtrace_summary( null, 4 ) );
 	}

--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -65,13 +65,13 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 
 	function render() {
 		echo "<div id='debug-bar-php'>";
-		echo '<h2><span>Total Warnings:</span>' . number_format( count( $this->warnings ) ) . "</h2>\n";
-		echo '<h2><span>Total Notices:</span>' . number_format( count( $this->notices ) ) . "</h2>\n";
+		echo '<h2><span>', __( 'Total Warnings:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->warnings ) ), "</h2>\n";
+		echo '<h2><span>', __( 'Total Notices:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->notices ) ), "</h2>\n";
 		if ( count( $this->warnings ) ) {
 			echo '<ol class="debug-bar-php-list">';
 			foreach ( $this->warnings as $location_message_stack ) {
 				list( $location, $message, $stack) = $location_message_stack;
-				echo '<li class="debug-bar-php-warning">WARNING: ';
+				echo '<li class="debug-bar-php-warning">', __( 'WARNING:', 'debug-bar' ), ' ';
 				echo str_replace(ABSPATH, '', $location) . ' - ' . strip_tags($message);
 				echo '<br/>';
 				echo $stack;
@@ -83,7 +83,7 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 			echo '<ol class="debug-bar-php-list">';
 			foreach ( $this->notices as $location_message_stack) {
 				list( $location, $message, $stack) = $location_message_stack;
-				echo '<li class="debug-bar-php-notice">NOTICE: ';
+				echo '<li class="debug-bar-php-notice">', __( 'NOTICE:', 'debug-bar' ), ' ';
 				echo str_replace(ABSPATH, '', $location) . ' - ' . strip_tags($message);
 				echo '<br/>';
 				echo $stack;

--- a/panels/class-debug-bar-queries.php
+++ b/panels/class-debug-bar-queries.php
@@ -24,8 +24,10 @@ class Debug_Bar_Queries extends Debug_Bar_Panel {
 		if ( !empty($wpdb->queries) ) {
 			$show_many = isset($_GET['debug_queries']);
 
-			if ( $wpdb->num_queries > 500 && !$show_many )
+			if ( $wpdb->num_queries > 500 && ! $show_many ) {
+				/* translators: %s = a url. */
 				$out .= "<p>" . sprintf( __('There are too many queries to show easily! <a href="%s">Show them anyway</a>', 'debug-bar'), esc_url( add_query_arg( 'debug_queries', 'true' ) ) ) . "</p>";
+			}
 
 			$out .= '<ol class="wpd-queries">';
 			$counter = 0;
@@ -44,7 +46,8 @@ class Debug_Bar_Queries extends Debug_Bar_Panel {
 				$debug = str_replace( array( 'do_action, call_user_func_array' ), array( 'do_action' ), $debug );
 				$query = nl2br(esc_html($query));
 
-				$out .= "<li>$query<br/><div class='qdebug'>$debug <span>#{$counter} (" . number_format(sprintf('%0.1f', $elapsed * 1000), 1, '.', ',') . "ms)</span></div></li>\n";
+				/* translators: %d = duration time in microseconds. */
+				$out .= "<li>$query<br/><div class='qdebug'>$debug <span>#{$counter} (" . sprintf( __( '%0.1fms', 'debug-bar' ), number_format_i18n( ( $elapsed * 1000 ), 1 ) ) . ")</span></div></li>\n";
 			}
 			$out .= '</ol>';
 		} else {
@@ -66,12 +69,17 @@ class Debug_Bar_Queries extends Debug_Bar_Panel {
 		}
 
 		$heading = '';
-		if ( $wpdb->num_queries )
-			$heading .= '<h2><span>Total Queries:</span>' . number_format( $wpdb->num_queries ) . "</h2>\n";
-		if ( $total_time )
-			$heading .= '<h2><span>Total query time:</span>' . number_format(sprintf('%0.1f', $total_time * 1000), 1) . " ms</h2>\n";
-		if ( ! empty($EZSQL_ERROR) )
-			$heading .= '<h2><span>Total DB Errors:</span>' . number_format( count($EZSQL_ERROR) ) . "</h2>\n";
+		if ( $wpdb->num_queries ) {
+			$heading .= '<h2><span>' . __( 'Total Queries:', 'debug-bar' ) . '</span>' . number_format_i18n( $wpdb->num_queries ) . "</h2>\n";
+		}
+		if ( $total_time ) {
+			$heading .= '<h2><span>' . __( 'Total query time:', 'debug-bar' ) . '</span>';
+			/* translators: %d = duration time in microseconds. */
+			$heading .= sprintf( __( '%0.1f ms', 'debug-bar' ), number_format_i18n( ( $total_time * 1000 ), 1 ) ) . "</h2>\n";
+		}
+		if ( ! empty($EZSQL_ERROR) ) {
+			$heading .= '<h2><span>' . __( 'Total DB Errors:', 'debug-bar' ) . '</span>' . number_format_i18n( count( $EZSQL_ERROR ) ) . "</h2>\n";
+		}
 
 		$out = $heading . $out;
 

--- a/panels/class-debug-bar-request.php
+++ b/panels/class-debug-bar-request.php
@@ -14,36 +14,40 @@ class Debug_Bar_Request extends Debug_Bar_Panel {
 
 		echo "<div id='debug-bar-request'>";
 
-		if ( empty($wp->request) )
-			$request = 'None';
-		else
+		if ( empty( $wp->request ) ) {
+			$request = __( 'None', 'debug-bar' );
+		} else {
 			$request = $wp->request;
+		}
 
-		echo '<h3>Request:</h3>';
+		echo '<h3>', __( 'Request:', 'debug-bar' ), '</h3>';
 		echo '<p>' . esc_html( $request ) . '</p>';
 
-		if ( empty($wp->query_string) )
-			$query_string = 'None';
-		else
+		if ( empty( $wp->query_string ) ) {
+			$query_string = __( 'None', 'debug-bar' );
+		} else {
 			$query_string = $wp->query_string;
+		}
 
-		echo '<h3>Query String:</h3>';
+		echo '<h3>', __( 'Query String:', 'debug-bar' ), '</h3>';
 		echo '<p>' . esc_html( $query_string ) . '</p>';
 
-		if ( empty($wp->matched_rule) )
-			$matched_rule = 'None';
-		else
+		if ( empty( $wp->matched_rule ) ) {
+			$matched_rule = __( 'None', 'debug-bar' );
+		} else {
 			$matched_rule = $wp->matched_rule;
+		}
 
-		echo '<h3>Matched Rewrite Rule:</h3>';
+		echo '<h3>', __( 'Matched Rewrite Rule:', 'debug-bar' ), '</h3>';
 		echo '<p>' . esc_html( $matched_rule ) . '</p>';
 
-		if ( empty($wp->matched_query) )
-			$matched_query = 'None';
-		else
+		if ( empty( $wp->matched_query ) ) {
+			$matched_query = __( 'None', 'debug-bar' );
+		} else {
 			$matched_query = $wp->matched_query;
+		}
 
-		echo '<h3>Matched Rewrite Query:</h3>';
+		echo '<h3>', __( 'Matched Rewrite Query:', 'debug-bar' ), '</h3>';
 		echo '<p>' . esc_html( $matched_query ) . '</p>';
 
 		echo '</div>';

--- a/panels/class-debug-bar-wp-query.php
+++ b/panels/class-debug-bar-wp-query.php
@@ -16,75 +16,80 @@ class Debug_Bar_WP_Query extends Debug_Bar_Panel {
 			$post_type_object = get_post_type_object( $queried_object->post_type );
 
 		echo "<div id='debug-bar-wp-query'>";
-		echo '<h2><span>Queried Object ID:</span>' . get_queried_object_id() . "</h2>\n";
+		echo '<h2><span>', __( 'Queried Object ID:', 'debug-bar' ), '</span>', get_queried_object_id(), "</h2>\n";
 
 		// Determine the query type. Follows the template loader order.
 		$type = '';
-		if ( is_404() )
-			$type = '404';
-		elseif ( is_search() )
-			$type = 'Search';
-		elseif ( is_tax() )
-			$type = 'Taxonomy';
-		elseif ( is_front_page() )
-			$type = 'Front Page';
-		elseif ( is_home() )
-			$type = 'Home';
-		elseif ( is_attachment() )
-			$type = 'Attachment';
-		elseif ( is_single() )
-			$type = 'Single';
-		elseif ( is_page() )
-			$type = 'Page';
-		elseif ( is_category() )
-			$type = 'Category';
-		elseif ( is_tag() )
-			$type = 'Tag';
-		elseif ( is_author() )
-			$type = 'Author';
-		elseif ( is_date() )
-			$type = 'Date';
-		elseif ( is_archive() )
-			$type = 'Archive';
-		elseif ( is_paged() )
-			$type = 'Paged';
+		if ( is_404() ) {
+			$type = __( '404', 'debug-bar' );
+		} elseif ( is_search() ) {
+			$type = __( 'Search', 'debug-bar' );
+		} elseif ( is_tax() ) {
+			$type = __( 'Taxonomy', 'debug-bar' );
+		} elseif ( is_front_page() ) {
+			$type = __( 'Front Page', 'debug-bar' );
+		} elseif ( is_home() ) {
+			$type = __( 'Home', 'debug-bar' );
+		} elseif ( is_attachment() ) {
+			$type = __( 'Attachment', 'debug-bar' );
+		} elseif ( is_single() ) {
+			$type = __( 'Single', 'debug-bar' );
+		} elseif ( is_page() ) {
+			$type = __( 'Page', 'debug-bar' );
+		} elseif ( is_category() ) {
+			$type = __( 'Category', 'debug-bar' );
+		} elseif ( is_tag() ) {
+			$type = __( 'Tag', 'debug-bar' );
+		} elseif ( is_author() ) {
+			$type = __( 'Author', 'debug-bar' );
+		} elseif ( is_date() ) {
+			$type = __( 'Date', 'debug-bar' );
+		} elseif ( is_archive() ) {
+			$type = __( 'Archive', 'debug-bar' );
+		} elseif ( is_paged() ) {
+			$type = __( 'Paged', 'debug-bar' );
+		}
 
-		if ( !empty($type) )
-			echo '<h2><span>Query Type:</span>' . $type . "</h2>\n";
+		if ( ! empty( $type ) ) {
+			echo '<h2><span>', __( 'Query Type:', 'debug-bar' ), '</span>', $type, "</h2>\n";
+		}
 
-		if ( !empty($template) )
-			echo '<h2><span>Query Template:</span>' . basename($template) . "</h2>\n";
+		if ( ! empty( $template ) ) {
+			echo '<h2><span>', __( 'Query Template:', 'debug-bar' ), '</span>', basename( $template ), "</h2>\n";
+		}
 
 		$show_on_front = get_option( 'show_on_front' );
 		$page_on_front = get_option( 'page_on_front' );
 		$page_for_posts = get_option( 'page_for_posts' );
 
-		echo '<h2><span>Show on Front:</span>' . $show_on_front . "</h2>\n";
+		echo '<h2><span>', __( 'Show on Front:', 'debug-bar' ), '</span>', $show_on_front, "</h2>\n";
 		if ( 'page' == $show_on_front ) {
-			echo '<h2><span>Page for Posts:</span>' . $page_for_posts . "</h2>\n";
-			echo '<h2><span>Page on Front:</span>' . $page_on_front . "</h2>\n";
+			echo '<h2><span>', __( 'Page for Posts:', 'debug-bar' ), '</span>', $page_for_posts, "</h2>\n";
+			echo '<h2><span>', __( 'Page on Front:', 'debug-bar' ), '</span>', $page_on_front, "</h2>\n";
 		}
 
-		if ( isset( $post_type_object ) )
-			echo '<h2><span>Post Type:</span>' . $post_type_object->labels->singular_name . "</h2>\n";
+		if ( isset( $post_type_object ) ) {
+			echo '<h2><span>', __( 'Post Type:', 'debug-bar' ), '</span>', $post_type_object->labels->singular_name, "</h2>\n";
+		}
 
 		echo '<div class="clear"></div>';
 
-		if ( empty($wp_query->query) )
-			$query = 'None';
-		else
+		if ( empty($wp_query->query) ) {
+			$query = __( 'None', 'debug-bar' );
+		} else {
 			$query = http_build_query( $wp_query->query );
+		}
 
-		echo '<h3>Query Arguments:</h3>';
+		echo '<h3>', __( 'Query Arguments:', 'debug-bar' ), '</h3>';
 		echo '<p>' . esc_html( $query ) . '</p>';
 
 		if ( ! empty($wp_query->request) ) {
-			echo '<h3>Query SQL:</h3>';
+			echo '<h3>', __( 'Query SQL:', 'debug-bar' ), '</h3>';
 			echo '<p>' . esc_html( $wp_query->request ) . '</p>';
 		}
 
 		if ( ! is_null( $queried_object ) ) {
-			echo '<h3>Queried Object:</h3>';
+			echo '<h3>', __( 'Queried Object:', 'debug-bar' ), '</h3>';
 			echo '<table class="debug-bar-wp-query-list"><tbody>';
 			$this->_recursive_print_kv($queried_object);
 			echo '</tbody></table>';


### PR DESCRIPTION
PR/patch notes:
- A lot of the strings used already had localization calls around them. For those which didn't, I've added them.
- I have added translator comments for all strings using variable replacements. In some cases this necessitated some layout changes of the code.
- Added a static `load_textdomain()` method to actually load translations.
  This method is compatible with use of this plugin as a must-use plugin which is often the case in dev environments.
  I've chosen to make this method static so as to allow add-on plugins to use this method too instead of having to implement this logic themselves (which is currently the case in about 50% of the add-ons - blame me ;-) )
- Replaced all instances of `number_format()` for string output with `number_format_i18n()`.
  If no localized use of separators is needed here, then the usage of `number_format()` was superfluous in the first place and those calls should be replaced with `absint()`.
- Generated the .pot base file.
- Tidied up the code style of the lines touched.
