### PR TITLE
No passing $this by reference.

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -21,9 +21,10 @@ class Debug_Bar {
 	var $panels = array();
 
 	function __construct() {
-		if ( defined('DOING_AJAX') && DOING_AJAX )
-			add_action( 'admin_init', array( &$this, 'init_ajax' ) );
-		add_action( 'admin_bar_init', array( &$this, 'init' ) );
+		if ( defined('DOING_AJAX') && DOING_AJAX ) {
+			add_action( 'admin_init', array( $this, 'init_ajax' ) );
+		}
+		add_action( 'admin_bar_init', array( $this, 'init' ) );
 	}
 
 	function Debug_Bar() {
@@ -34,12 +35,12 @@ class Debug_Bar {
 		if ( ! is_super_admin() || ! is_admin_bar_showing() || $this->is_wp_login() )
 			return;
 
-		add_action( 'admin_bar_menu',               array( &$this, 'admin_bar_menu' ), 1000 );
-		add_action( 'admin_footer',                 array( &$this, 'render' ), 1000 );
-		add_action( 'wp_footer',                    array( &$this, 'render' ), 1000 );
-		add_action( 'wp_head',                      array( &$this, 'ensure_ajaxurl' ), 1 );
-		add_filter( 'body_class',                   array( &$this, 'body_class' ) );
-		add_filter( 'admin_body_class',             array( &$this, 'body_class' ) );
+		add_action( 'admin_bar_menu',               array( $this, 'admin_bar_menu' ), 1000 );
+		add_action( 'admin_footer',                 array( $this, 'render' ), 1000 );
+		add_action( 'wp_footer',                    array( $this, 'render' ), 1000 );
+		add_action( 'wp_head',                      array( $this, 'ensure_ajaxurl' ), 1 );
+		add_filter( 'body_class',                   array( $this, 'body_class' ) );
+		add_filter( 'admin_body_class',             array( $this, 'body_class' ) );
 
 		$this->requirements();
 		$this->enqueue();

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -9,9 +9,9 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 	function init() {
 		$this->title( __('Deprecated', 'debug-bar') );
 
-		add_action( 'deprecated_function_run', array( &$this, 'deprecated_function_run' ), 10, 3 );
-		add_action( 'deprecated_file_included', array( &$this, 'deprecated_file_included' ), 10, 4 );
-		add_action( 'deprecated_argument_run',  array( &$this, 'deprecated_argument_run' ),  10, 3 );
+		add_action( 'deprecated_function_run', array( $this, 'deprecated_function_run' ), 10, 3 );
+		add_action( 'deprecated_file_included', array( $this, 'deprecated_file_included' ), 10, 4 );
+		add_action( 'deprecated_argument_run',  array( $this, 'deprecated_argument_run' ),  10, 3 );
 
 		// Silence E_NOTICE for deprecated usage.
 		foreach ( array( 'function', 'file', 'argument' ) as $item )

--- a/panels/class-debug-bar-panel.php
+++ b/panels/class-debug-bar-panel.php
@@ -12,7 +12,7 @@ class Debug_Bar_Panel {
 			return;
 		}
 
-		add_filter( 'debug_bar_classes', array( &$this, 'debug_bar_classes' ) );
+		add_filter( 'debug_bar_classes', array( $this, 'debug_bar_classes' ) );
 	}
 
 	function Debug_Bar_Panel( $title = '' ) {


### PR DESCRIPTION
PHP 5 always passes objects by reference, so no need to use `&`.
