### PR TITLE
Prevent error notices in PHP 5.2

### DIFF
--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -29,6 +29,13 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 	function error_handler( $type, $message, $file, $line ) {
 		$_key = md5( $file . ':' . $line . ':' . $message );
 
+		if ( ! defined( 'E_DEPRECATED' ) ) {
+			define( 'E_DEPRECATED', 8192 );
+		}
+		if ( ! defined( 'E_USER_DEPRECATED' ) )	{
+			define( 'E_USER_DEPRECATED', 16384 );
+		}
+
 		switch ( $type ) {
 			case E_WARNING :
 			case E_USER_WARNING :


### PR DESCRIPTION
Prevent error notices in PHP 5.2 for constants which were only introduced in PHP 5.3.

This fixes: https://wordpress.org/support/topic/use-of-undefined-constant-e_deprecated-assumed-e_deprecated?replies=2
