### PR TITLE
Fix HTML error: Element “div” not allowed as child of element “h2” in…

### DIFF
--- a/css/debug-bar.dev.css
+++ b/css/debug-bar.dev.css
@@ -240,6 +240,15 @@ body.debug-bar-maximized.debug-bar-visible {
 	margin-bottom: 5px;
 }
 
+#querylist h2 span#debug-bar-js-error-count {
+	font-size: inherit;
+	color: inherit;
+	text-transform: inherit;
+	white-space: inherit;
+	display: inherit;
+	margin-bottom: inherit;
+}
+
 #object-cache-stats h2 {
 	border: none;
 	float: none;

--- a/panels/class-debug-bar-js.php
+++ b/panels/class-debug-bar-js.php
@@ -14,7 +14,7 @@ class Debug_Bar_JS extends Debug_Bar_Panel {
 
 	function render() {
 		echo '<div id="debug-bar-js">';
-		echo '<h2><span>' . __( 'Total Errors:', 'debug-bar' ) . "</span><div id='debug-bar-js-error-count'>0</div></h2>\n";
+		echo '<h2><span>' . __( 'Total Errors:', 'debug-bar' ) . "</span><span id='debug-bar-js-error-count'>0</span></h2>\n";
 		echo '<ol class="debug-bar-js-list" id="debug-bar-js-errors"></ol>' . "\n";
 		echo '</div>';
 	}


### PR DESCRIPTION
… this context.

Also fix the display of the count after the change to `<span>`.
