### PR TITLE
Allow for large number of add-ons.

### DIFF
--- a/css/debug-bar.dev.css
+++ b/css/debug-bar.dev.css
@@ -121,7 +121,7 @@ body.debug-bar-maximized.debug-bar-visible {
 	bottom: 0;
 	z-index: 100;
 
-	overflow: hidden;
+	overflow: auto;
 	text-shadow: 0 1px 1px rgba( 0, 0, 0, 0.9 );
 	background: #333;
 	-webkit-box-shadow: inset -3px 0 6px rgba( 0, 0, 0, 0.4 );
@@ -203,9 +203,10 @@ body.debug-bar-maximized.debug-bar-visible {
 }
 
 #debug-menu-links li a {
+	box-sizing: content-box;
 	padding: 0 20px;
 	width: 210px;
-	line-height: 40px;
+	line-height: 32px;
 	outline: none;
 	display: block;
 	margin: 0;


### PR DESCRIPTION
As there are now a lot of Debug Bar add-ons out there, the panel list on the left might run out of screen estate.
The tweaks in this PR allow for a scroll bar to be added to the panel list and make the list a little more compact.

Also fixes an issue where the panel menu links wouldn't be full-width if the front-end theme changed the `box-sizing`.
