### PR TITLE
Fix potential usability issue when theme defines a light H2 color.

### DIFF
--- a/css/debug-bar.dev.css
+++ b/css/debug-bar.dev.css
@@ -226,6 +226,7 @@ body.debug-bar-maximized.debug-bar-visible {
 	padding: 5px 10px 15px;
 	clear: none;
 	text-align: center;
+	color: #000;
 	font-family: georgia, times, serif;
 	font-size: 28px;
 	margin: 15px 10px 15px 0 !important;


### PR DESCRIPTION
CSS specificity issue as described here:
https://wordpress.org/support/topic/plugin-debug-bar-white-on-near-white

Tested, reproduced & fixed.

Props:
https://wordpress.org/support/profile/jb510
