### PR TITLE
Make the eventlistener for the js panel independent of whether jQuery…

### DIFF
--- a/panels/class-debug-bar-js.php
+++ b/panels/class-debug-bar-js.php
@@ -9,7 +9,7 @@ class Debug_Bar_JS extends Debug_Bar_Panel {
 		// attach here instead of debug_bar_enqueue_scripts
 		// because we want to be as early as possible!
 		$suffix = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ? '.dev' : '';
-		wp_enqueue_script( 'debug-bar-js', plugins_url( "js/debug-bar-js$suffix.js", dirname(__FILE__) ), array(), '20111216' );
+		wp_enqueue_script( 'debug-bar-js', plugins_url( "js/debug-bar-js$suffix.js", dirname(__FILE__) ), array( 'jquery' ), '20111216' );
 	}
 
 	function render() {


### PR DESCRIPTION
… is available or not.

Fixes:
https://wordpress.org/support/topic/error-jquery-is-not-defineddebug-bar-jsjs
