### PR TITLE
Use `self` keyword instead of class name + trigger deprecated notice …

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -27,7 +27,8 @@ class Debug_Bar {
 	}
 
 	function Debug_Bar() {
-		Debug_Bar::__construct();
+		_deprecated_constructor( __METHOD__, '0.8.5', __CLASS__ );
+		self::__construct();
 	}
 
 	function init() {

--- a/panels/class-debug-bar-panel.php
+++ b/panels/class-debug-bar-panel.php
@@ -16,7 +16,8 @@ class Debug_Bar_Panel {
 	}
 
 	function Debug_Bar_Panel( $title = '' ) {
-		Debug_Bar_Panel::__construct( $title );
+		_deprecated_constructor( __METHOD__, '0.8.5', __CLASS__ );
+		self::__construct( $title );
 	}
 
 	/**


### PR DESCRIPTION
…when used.
