### PR TITLE
Improve logging of all notices

### DIFF
--- a/css/debug-bar.dev.css
+++ b/css/debug-bar.dev.css
@@ -361,7 +361,8 @@ body.debug-bar-maximized.debug-bar-visible {
 #debug-bar-doingitwrong ol.debug-bar-deprecated-list li {
 	padding: 10px;
 	margin: 0 0 10px 0;
-	background: #f0f0f0;
+	background-color: #ffffe0;
+	border: 1px solid #e6db55;
 }
 
 #debug-bar-wp-query table.debug-bar-wp-query-list {

--- a/css/debug-bar.dev.css
+++ b/css/debug-bar.dev.css
@@ -221,6 +221,30 @@ body.debug-bar-maximized.debug-bar-visible {
 	background: rgba( 0, 0, 0, 0.2 );
 }
 
+#debug-menu-links li span.debug-bar-issue-count {
+	float: right;
+	background-color: #ee6f00;
+	background-image: -moz-linear-gradient(bottom, #d54e21, #ee6f00);
+	background-image: -webkit-gradient(linear, left bottom, left top, from(#d54e21), to(#ee6f00));
+	color: #fff;
+	text-shadow: 0 -1px 0 #700;
+	border-radius: 50%;
+	font-size: 85%;
+	display: inline-block;
+	width: 21px;
+	height: 21px;
+	line-height: 20px;
+	margin: 6px 5px 0 0;
+	text-align: center;
+	vertical-align: middle;
+}
+
+#debug-menu-links li span.debug-bar-issue-count.debug-bar-issue-warnings {
+	background-color: #d00;
+	background-image: -moz-linear-gradient(bottom, #c40000, #d00);
+	background-image: -webkit-gradient(linear, left bottom, left top, from(#c40000), to(#d00));
+}
+
 #querylist h2 {
 	float: left;
 	min-width: 150px;

--- a/css/debug-bar.dev.css
+++ b/css/debug-bar.dev.css
@@ -12,40 +12,40 @@
 	background: -webkit-gradient(linear, left bottom, left top, from(#555), to(#3e3e3e));
 }
 
-#wpadminbar #wp-admin-bar-debug-bar.debug-bar-php-notice-summary,
-#wpadminbar #wp-admin-bar-debug-bar.debug-bar-php-notice-summary .ab-item:focus {
+#wpadminbar #wp-admin-bar-debug-bar.debug-bar-notice-summary,
+#wpadminbar #wp-admin-bar-debug-bar.debug-bar-notice-summary .ab-item:focus {
 	background-color: #ff8922;
 	background-image: -moz-linear-gradient(bottom, #ee6f00, #ff8922);
 	background-image: -webkit-gradient(linear, left bottom, left top, from(#ee6f00), to(#ff8922));
 }
 
-#wpadminbar #wp-admin-bar-debug-bar.debug-bar-php-notice-summary .ab-item:hover,
-.debug-bar-visible #wpadminbar #wp-admin-bar-debug-bar.debug-bar-php-notice-summary,
-.debug-bar-visible #wpadminbar #wp-admin-bar-debug-bar.debug-bar-php-notice-summary .ab-item:focus {
+#wpadminbar #wp-admin-bar-debug-bar.debug-bar-notice-summary .ab-item:hover,
+.debug-bar-visible #wpadminbar #wp-admin-bar-debug-bar.debug-bar-notice-summary,
+.debug-bar-visible #wpadminbar #wp-admin-bar-debug-bar.debug-bar-notice-summary .ab-item:focus {
 	background-color: #ee6f00;
 	background-image: -moz-linear-gradient(bottom, #ff8922, #ee6f00 );
 	background-image: -webkit-gradient(linear, left bottom, left top, from(#ff8922), to(#ee6f00));
 }
-#wpadminbar #wp-admin-bar-debug-bar.debug-bar-php-notice-summary .ab-item {
+#wpadminbar #wp-admin-bar-debug-bar.debug-bar-notice-summary .ab-item {
 	color: #fff;
 	text-shadow: 0 -1px 0 #884000;
 }
 
-#wpadminbar #wp-admin-bar-debug-bar.debug-bar-php-warning-summary,
-#wpadminbar #wp-admin-bar-debug-bar.debug-bar-php-warning-summary .ab-item:focus {
-	background-color: #f44;
-	background-image: -moz-linear-gradient(bottom, #d00, #f44);
-	background-image: -webkit-gradient(linear, left bottom, left top, from(#d00), to(#f44));
+#wpadminbar #wp-admin-bar-debug-bar.debug-bar-warning-summary,
+#wpadminbar #wp-admin-bar-debug-bar.debug-bar-warning-summary .ab-item:focus {
+	background-color: #f44 !important;
+	background-image: -moz-linear-gradient(bottom, #d00, #f44) !important;
+	background-image: -webkit-gradient(linear, left bottom, left top, from(#d00), to(#f44)) !important;
 }
 
-#wpadminbar #wp-admin-bar-debug-bar.debug-bar-php-warning-summary .ab-item:hover,
-.debug-bar-visible #wpadminbar #wp-admin-bar-debug-bar.debug-bar-php-warning-summary,
-.debug-bar-visible #wpadminbar #wp-admin-bar-debug-bar.debug-bar-php-warning-summary .ab-item:focus {
-	background-color: #d00;
-	background-image: -moz-linear-gradient(bottom, #f44, #d00 );
-	background-image: -webkit-gradient(linear, left bottom, left top, from(#f44), to(#d00));
+#wpadminbar #wp-admin-bar-debug-bar.debug-bar-warning-summary .ab-item:hover,
+.debug-bar-visible #wpadminbar #wp-admin-bar-debug-bar.debug-bar-warning-summary,
+.debug-bar-visible #wpadminbar #wp-admin-bar-debug-bar.debug-bar-warning-summary .ab-item:focus {
+	background-color: #d00 !important;
+	background-image: -moz-linear-gradient(bottom, #f44, #d00 ) !important;
+	background-image: -webkit-gradient(linear, left bottom, left top, from(#f44), to(#d00)) !important;
 }
-#wpadminbar #wp-admin-bar-debug-bar.debug-bar-php-warning-summary .ab-item {
+#wpadminbar #wp-admin-bar-debug-bar.debug-bar-warning-summary .ab-item {
 	color: #fff;
 	text-shadow: 0 -1px 0 #700;
 }

--- a/css/debug-bar.dev.css
+++ b/css/debug-bar.dev.css
@@ -349,14 +349,16 @@ body.debug-bar-maximized.debug-bar-visible {
 	border: 1px solid #e6db55;
 }
 
-#debug-bar-deprecated ol.debug-bar-deprecated-list {
+#debug-bar-deprecated ol.debug-bar-deprecated-list,
+#debug-bar-doingitwrong ol.debug-bar-deprecated-list {
 	padding: 0 !important;
 	margin: 0 !important;
 	list-style: none;
 	clear: left;
 }
 
-#debug-bar-deprecated ol.debug-bar-deprecated-list li {
+#debug-bar-deprecated ol.debug-bar-deprecated-list li,
+#debug-bar-doingitwrong ol.debug-bar-deprecated-list li {
 	padding: 10px;
 	margin: 0 0 10px 0;
 	background: #f0f0f0;

--- a/debug-bar.php
+++ b/debug-bar.php
@@ -33,6 +33,7 @@ class Debug_Bar {
 		$this->early_requirements();
 		Debug_Bar_PHP::start_logging();
 		Debug_Bar_Deprecated::start_logging();
+		Debug_Bar_Doing_It_Wrong::start_logging();
 	}
 
 	function Debug_Bar() {
@@ -44,6 +45,7 @@ class Debug_Bar {
 		if ( ! $this->enable_debug_bar() ) {
 			Debug_Bar_PHP::stop_logging();
 			Debug_Bar_Deprecated::stop_logging();
+			Debug_Bar_Doing_It_Wrong::stop_logging();
 			return;
 		}
 
@@ -97,6 +99,7 @@ class Debug_Bar {
 		if ( ! $this->enable_debug_bar( true ) ) {
 			Debug_Bar_PHP::stop_logging();
 			Debug_Bar_Deprecated::stop_logging();
+			Debug_Bar_Doing_It_Wrong::stop_logging();
 			return;
 		}
 
@@ -106,7 +109,7 @@ class Debug_Bar {
 
 	function early_requirements() {
 		require_once( $this->path . '/compat.php' );
-		$recs = array( 'panel', 'php', 'deprecated' );
+		$recs = array( 'panel', 'php', 'deprecated', 'doingitwrong' );
 		$this->include_files( $recs );
 	}
 
@@ -137,6 +140,7 @@ class Debug_Bar {
 			'Debug_Bar_Queries',
 			'Debug_Bar_WP_Query',
 			'Debug_Bar_Deprecated',
+			'Debug_Bar_Doing_It_Wrong',
 			'Debug_Bar_Request',
 			'Debug_Bar_Object_Cache',
 			'Debug_Bar_JS',

--- a/debug-bar.php
+++ b/debug-bar.php
@@ -19,6 +19,7 @@
  */
 
 class Debug_Bar {
+	var $path;
 	var $panels = array();
 
 	function __construct() {
@@ -26,6 +27,12 @@ class Debug_Bar {
 			add_action( 'admin_init', array( $this, 'init_ajax' ) );
 		}
 		add_action( 'admin_bar_init', array( $this, 'init' ) );
+
+		$this->path = plugin_dir_path( __FILE__ );
+
+		$this->early_requirements();
+		Debug_Bar_PHP::start_logging();
+		Debug_Bar_Deprecated::start_logging();
 	}
 
 	function Debug_Bar() {
@@ -35,6 +42,8 @@ class Debug_Bar {
 
 	function init() {
 		if ( ! $this->enable_debug_bar() ) {
+			Debug_Bar_PHP::stop_logging();
+			Debug_Bar_Deprecated::stop_logging();
 			return;
 		}
 
@@ -86,6 +95,8 @@ class Debug_Bar {
 
 	function init_ajax() {
 		if ( ! $this->enable_debug_bar( true ) ) {
+			Debug_Bar_PHP::stop_logging();
+			Debug_Bar_Deprecated::stop_logging();
 			return;
 		}
 
@@ -93,12 +104,21 @@ class Debug_Bar {
 		$this->init_panels();
 	}
 
+	function early_requirements() {
+		require_once( $this->path . '/compat.php' );
+		$recs = array( 'panel', 'php', 'deprecated' );
+		$this->include_files( $recs );
+	}
+
 	function requirements() {
-		$path = plugin_dir_path( __FILE__ );
-		require_once( $path . '/compat.php' );
-		$recs = array( 'panel', 'php', 'queries', 'request', 'wp-query', 'object-cache', 'deprecated', 'js' );
-		foreach ( $recs as $rec )
-			require_once "$path/panels/class-debug-bar-$rec.php";
+		$recs = array( 'queries', 'request', 'wp-query', 'object-cache', 'js' );
+		$this->include_files( $recs );
+	}
+
+	function include_files( $recs ) {
+		foreach ( $recs as $rec ) {
+			require_once $this->path . "/panels/class-debug-bar-$rec.php";
+		}
 	}
 
 	function enqueue() {

--- a/debug-bar.php
+++ b/debug-bar.php
@@ -176,7 +176,7 @@ class Debug_Bar {
 		global $wp_admin_bar;
 
 		$classes = apply_filters( 'debug_bar_classes', array() );
-		$classes = implode( " ", $classes );
+		$classes = implode( " ", array_unique( $classes ) );
 
 		/* Add the main siteadmin menu item */
 		$wp_admin_bar->add_menu( array(

--- a/js/debug-bar-js.dev.js
+++ b/js/debug-bar-js.dev.js
@@ -36,8 +36,8 @@
 			button = document.getElementById( 'wp-admin-bar-debug-bar' );
 			if ( !button )
 				return; // how did this happen?
-			if ( button.className.indexOf( 'debug-bar-php-warning-summary' ) === -1 )
-				button.className = button.className + ' debug-bar-php-warning-summary';
+			if ( button.className.indexOf( 'debug-bar-warning-summary' ) === -1 )
+				button.className = button.className + ' debug-bar-warning-summary';
 
 			tab = document.getElementById('debug-menu-link-Debug_Bar_JS');
 			if ( tab )

--- a/js/debug-bar-js.dev.js
+++ b/js/debug-bar-js.dev.js
@@ -1,5 +1,5 @@
 (function() {
-	var count, list, dbjsError,
+	var count, menuCount, list, dbjsError,
 		rawCount = 0,
 		errors = [];
 
@@ -22,6 +22,8 @@
 
 		rawCount++;
 
+		if ( !menuCount )
+			menuCount = document.getElementById( 'debug-bar-js-issue-count' );
 		if ( !count )
 			count = document.getElementById( 'debug-bar-js-error-count' );
 		if ( !list )
@@ -43,6 +45,7 @@
 		}
 
 		count.textContent = rawCount;
+		menuCount.textContent = rawCount;
 		errorLine = document.createElement( 'li' );
 		errorLine.className = 'debug-bar-js-error';
 		errorLine.textContent = errorMsg;

--- a/js/debug-bar-js.dev.js
+++ b/js/debug-bar-js.dev.js
@@ -22,26 +22,40 @@
 
 		rawCount++;
 
-		if ( !menuCount )
+		if ( ! menuCount ) {
 			menuCount = document.getElementById( 'debug-bar-js-issue-count' );
-		if ( !count )
+		}
+		if ( ! count ) {
 			count = document.getElementById( 'debug-bar-js-error-count' );
-		if ( !list )
+		}
+		if ( ! list ) {
 			list = document.getElementById( 'debug-bar-js-errors' );
+		}
 
-		if ( !count || !list )
+		if ( ! count || !list ) {
 			return; // threw way too early... @todo cache these?
+		}
 
 		if ( 1 == rawCount ) {
 			button = document.getElementById( 'wp-admin-bar-debug-bar' );
-			if ( !button )
+			if ( ! button ) {
 				return; // how did this happen?
-			if ( button.className.indexOf( 'debug-bar-warning-summary' ) === -1 )
+			}
+			if ( button.className.indexOf( 'debug-bar-warning-summary' ) === -1 ) {
 				button.className = button.className + ' debug-bar-warning-summary';
+			}
 
-			tab = document.getElementById('debug-menu-link-Debug_Bar_JS');
-			if ( tab )
+			tab = document.getElementById( 'debug-menu-link-Debug_Bar_JS' );
+			if ( tab ) {
 				tab.style.display = 'block';
+			}
+
+			if ( menuCount.className.indexOf( 'debug-bar-issue-count' ) === -1 ) {
+				menuCount.className = menuCount.className + ' debug-bar-issue-count';
+			}
+			if ( menuCount.className.indexOf( 'debug-bar-issue-warnings' ) === -1 ) {
+				menuCount.className = menuCount.className + ' debug-bar-issue-warnings';
+			}
 		}
 
 		count.textContent = rawCount;

--- a/js/debug-bar.dev.js
+++ b/js/debug-bar.dev.js
@@ -113,11 +113,11 @@ $(document ).ready( function() {
 	hasNotices   = $( '#debug-menu-links span.debug-bar-issue-count' );
 	button       = $( '#wp-admin-bar-debug-bar' );
 
-	if ( 0 !== hasPHPErrors.length ) {
+	if ( 0 < hasPHPErrors.length ) {
 		if ( button && ! button.hasClass( 'debug-bar-warning-summary' ) ) {
 			button.addClass( 'debug-bar-warning-summary' );
 		}
-	} else if ( 0 !== hasNotices.length ) {
+	} else if ( 0 < hasNotices.length ) {
 		button = $( '#wp-admin-bar-debug-bar' );
 		if ( button && ! button.hasClass( 'debug-bar-notice-summary' ) ) {
 			button.addClass( 'debug-bar-notice-summary' );

--- a/js/debug-bar.dev.js
+++ b/js/debug-bar.dev.js
@@ -102,4 +102,27 @@ wpDebugBar.Panel = function() {
 
 $(document).ready( wpDebugBar.init );
 
+/**
+ * Add the 'warning' class to the admin bar button for PHP errors encountered after the admin bar
+ * was initialized.
+ */
+$(document ).ready( function() {
+	var hasPHPErrors, hasNotices, button;
+
+	hasPHPErrors = $( '#debug-menu-link-Debug_Bar_PHP span.debug-bar-issue-warnings' );
+	hasNotices   = $( '#debug-menu-links span.debug-bar-issue-count' );
+	button       = $( '#wp-admin-bar-debug-bar' );
+
+	if ( 0 !== hasPHPErrors.length ) {
+		if ( button && ! button.hasClass( 'debug-bar-warning-summary' ) ) {
+			button.addClass( 'debug-bar-warning-summary' );
+		}
+	} else if ( 0 !== hasNotices.length ) {
+		button = $( '#wp-admin-bar-debug-bar' );
+		if ( button && ! button.hasClass( 'debug-bar-notice-summary' ) ) {
+			button.addClass( 'debug-bar-notice-summary' );
+		}
+	}
+});
+
 })(jQuery);

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -52,6 +52,13 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		return count( self::$deprecated_functions ) + count( self::$deprecated_files ) + count( self::$deprecated_arguments ) + count( self::$deprecated_constructors );
 	}
 
+	function debug_bar_classes( $classes ) {
+		if ( $this->get_total() > 0 ) {
+			$classes[] = 'debug-bar-notice-summary';
+		}
+		return $classes;
+	}
+
 	function render() {
 		echo '<div id="debug-bar-deprecated">';
 

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -67,10 +67,10 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		$this->render_title( __( 'Total Arguments:', 'debug-bar' ), count( self::$deprecated_arguments ) );
 		$this->render_title( __( 'Total Constructors:', 'debug-bar' ), count( self::$deprecated_constructors ) );
 
-		$this->render_list( self::$deprecated_functions, 'deprecated-function' );
-		$this->render_list( self::$deprecated_files, 'deprecated-file' );
-		$this->render_list( self::$deprecated_arguments, 'deprecated-argument' );
-		$this->render_list( self::$deprecated_constructors, 'deprecated-constructor' );
+		$this->render_list( self::$deprecated_functions, 'deprecated-function', __( 'DEPRECATED FUNCTION:', 'debug-bar' ) );
+		$this->render_list( self::$deprecated_files, 'deprecated-file', __( 'DEPRECATED FILE:', 'debug-bar' ) );
+		$this->render_list( self::$deprecated_arguments, 'deprecated-argument', __( 'DEPRECATED ARGUMENT:', 'debug-bar' ) );
+		$this->render_list( self::$deprecated_constructors, 'deprecated-constructor', __( 'DEPRECATED CONSTRUCTOR:', 'debug-bar' ) );
 
 		echo '</div>';
 	}
@@ -79,7 +79,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		echo '<h2><span>', $title, '</span>', absint( $count ), "</h2>\n";
 	}
 
-	function render_list( $calls, $class ) {
+	function render_list( $calls, $class, $type ) {
 		if ( count( $calls ) ) {
 			echo '<ol class="debug-bar-deprecated-list">';
 			foreach ( $calls as $location => $message_stack ) {
@@ -87,7 +87,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 
 				echo '
 				<li class="debug-bar-', $class, '">',
-				str_replace( ABSPATH, '', $location ), ' - ', strip_tags( $message ),
+				$type, ' ', str_replace( ABSPATH, '', $location ), ' - ', strip_tags( $message ),
 				'<br/>',
 				$stack,
 				'</li>';

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -5,14 +5,16 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 	static $deprecated_functions = array();
 	static $deprecated_files = array();
 	static $deprecated_arguments = array();
+	static $deprecated_constructors = array();
 
 	static function start_logging() {
 		add_action( 'deprecated_function_run', array( __CLASS__, 'deprecated_function_run' ), 10, 3 );
 		add_action( 'deprecated_file_included', array( __CLASS__, 'deprecated_file_included' ), 10, 4 );
 		add_action( 'deprecated_argument_run',  array( __CLASS__, 'deprecated_argument_run' ),  10, 3 );
+		add_action( 'deprecated_constructor_run',  array( __CLASS__, 'deprecated_constructor_run' ),  10, 3 );
 
 		// Silence E_NOTICE for deprecated usage.
-		foreach ( array( 'function', 'file', 'argument' ) as $item ) {
+		foreach ( array( 'function', 'file', 'argument', 'constructor' ) as $item ) {
 			add_filter( "deprecated_{$item}_trigger_error", '__return_false' );
 		}
 	}
@@ -21,9 +23,10 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		remove_action( 'deprecated_function_run', array( __CLASS__, 'deprecated_function_run' ), 10 );
 		remove_action( 'deprecated_file_included', array( __CLASS__, 'deprecated_file_included' ), 10 );
 		remove_action( 'deprecated_argument_run',  array( __CLASS__, 'deprecated_argument_run' ),  10 );
+		remove_action( 'deprecated_constructor_run',  array( __CLASS__, 'deprecated_constructor_run' ),  10 );
 
 		// Don't silence E_NOTICE for deprecated usage.
-		foreach ( array( 'function', 'file', 'argument' ) as $item ) {
+		foreach ( array( 'function', 'file', 'argument', 'constructor' ) as $item ) {
 			remove_filter( "deprecated_{$item}_trigger_error", '__return_false' );
 		}
 	}
@@ -37,6 +40,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			count( self::$deprecated_functions )
 			|| count( self::$deprecated_files )
 			|| count( self::$deprecated_arguments )
+			|| count( self::$deprecated_constructors )
 		);
 	}
 
@@ -46,10 +50,12 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		$this->render_title( __( 'Total Functions:', 'debug-bar' ), count( self::$deprecated_functions ) );
 		$this->render_title( __( 'Total Files:', 'debug-bar' ), count( self::$deprecated_files ) );
 		$this->render_title( __( 'Total Arguments:', 'debug-bar' ), count( self::$deprecated_arguments ) );
+		$this->render_title( __( 'Total Constructors:', 'debug-bar' ), count( self::$deprecated_constructors ) );
 
 		$this->render_list( self::$deprecated_functions, 'deprecated-function' );
 		$this->render_list( self::$deprecated_files, 'deprecated-file' );
 		$this->render_list( self::$deprecated_arguments, 'deprecated-argument' );
+		$this->render_list( self::$deprecated_constructors, 'deprecated-constructor' );
 
 		echo '</div>';
 	}
@@ -132,5 +138,27 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		}
 
 		self::$deprecated_arguments[ $file . ':' . $line ] = array( $message, wp_debug_backtrace_summary( null, $bt ) );
+	}
+
+	static function deprecated_constructor_run( $class, $version, $parent_class = '' ) {
+		$backtrace = debug_backtrace( false );
+		$bt = 4;
+		if ( ! isset( $backtrace[4]['file'] ) && 'call_user_func_array' == $backtrace[5]['function'] ) {
+			$bt = 6;
+		}
+		$file = $backtrace[ $bt ]['file'];
+		$line = $backtrace[ $bt ]['line'];
+
+		if ( ! empty( $parent_class ) ) {
+			/* translators: 1: PHP class name, 2: PHP parent class name, 3: version number, 4: __construct() method */
+			$message = sprintf( __( 'The called constructor method for %1$s in %2$s is <strong>deprecated</strong> since version %3$s! Use %4$s instead.', 'debug-bar' ),
+				$class, $parent_class, $version, '<pre>__construct()</pre>' );
+		} else {
+			/* translators: 1: PHP class name, 2: version number, 3: __construct() method */
+			$message = sprintf( __( 'The called constructor method for %1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.', 'debug-bar' ),
+				$class, $version, '<pre>__construct()</pre>' );
+		}
+
+		self::$deprecated_constructors[ $file . ':' . $line ] = array( $message, wp_debug_backtrace_summary( null, $bt ) );
 	}
 }

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -67,10 +67,10 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		$this->render_title( __( 'Total Arguments:', 'debug-bar' ), count( self::$deprecated_arguments ) );
 		$this->render_title( __( 'Total Constructors:', 'debug-bar' ), count( self::$deprecated_constructors ) );
 
-		$this->render_list( self::$deprecated_functions, 'deprecated-function', __( 'DEPRECATED FUNCTION:', 'debug-bar' ) );
-		$this->render_list( self::$deprecated_files, 'deprecated-file', __( 'DEPRECATED FILE:', 'debug-bar' ) );
-		$this->render_list( self::$deprecated_arguments, 'deprecated-argument', __( 'DEPRECATED ARGUMENT:', 'debug-bar' ) );
-		$this->render_list( self::$deprecated_constructors, 'deprecated-constructor', __( 'DEPRECATED CONSTRUCTOR:', 'debug-bar' ) );
+		$this->render_list( self::$deprecated_functions, __( 'DEPRECATED FUNCTION:', 'debug-bar' ), 'deprecated-function' );
+		$this->render_list( self::$deprecated_files, __( 'DEPRECATED FILE:', 'debug-bar' ), 'deprecated-file' );
+		$this->render_list( self::$deprecated_arguments, __( 'DEPRECATED ARGUMENT:', 'debug-bar' ), 'deprecated-argument' );
+		$this->render_list( self::$deprecated_constructors, __( 'DEPRECATED CONSTRUCTOR:', 'debug-bar' ), 'deprecated-constructor' );
 
 		echo '</div>';
 	}
@@ -79,7 +79,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		echo '<h2><span>', $title, '</span>', absint( $count ), "</h2>\n";
 	}
 
-	function render_list( $calls, $class, $type ) {
+	function render_list( $calls, $type, $class ) {
 		if ( count( $calls ) ) {
 			echo '<ol class="debug-bar-deprecated-list">';
 			foreach ( $calls as $location => $message_stack ) {

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -113,6 +113,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			$message = sprintf( __('%1$s is <strong>deprecated</strong> since version %2$s with no alternative available.', 'debug-bar'), $function, $version );
 		}
 
+		error_log( $message );
 		self::$deprecated_functions[ $file . ':' . $line ] = array( $message, wp_debug_backtrace_summary( null, $bt ) );
 	}
 
@@ -130,10 +131,11 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			$message = sprintf( __('%1$s is <strong>deprecated</strong> since version %2$s with no alternative available.', 'debug-bar'), $file_abs, $version ) . $message;
 		}
 
+		error_log( $message );
 		self::$deprecated_files[ $file . ':' . $line ] = array( $message, wp_debug_backtrace_summary( null, 4 ) );
 	}
 
-	static function deprecated_argument_run( $function, $message, $version) {
+	static function deprecated_argument_run( $function, $message, $version ) {
 		$backtrace = debug_backtrace( false );
 		if ( $function === 'define()' ) {
 			self::$deprecated_arguments[] = array( $message, '' );
@@ -152,6 +154,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			$message = sprintf( __('%1$s was called with an argument that is <strong>deprecated</strong> since version %2$s with no alternative available.'), $function, $version );
 		}
 
+		error_log( $message );
 		self::$deprecated_arguments[ $file . ':' . $line ] = array( $message, wp_debug_backtrace_summary( null, $bt ) );
 	}
 
@@ -174,6 +177,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 				$class, $version, '<pre>__construct()</pre>' );
 		}
 
+		error_log( $message );
 		self::$deprecated_constructors[ $file . ':' . $line ] = array( $message, wp_debug_backtrace_summary( null, $bt ) );
 	}
 }

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -33,15 +33,23 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 
 	function init() {
 		$this->title( __('Deprecated', 'debug-bar') );
+		$this->set_visible( false );
+	}
+
+	function is_visible() {
+		return ( $this->get_total() > 0 );
 	}
 
 	function prerender() {
-		$this->set_visible(
-			count( self::$deprecated_functions )
-			|| count( self::$deprecated_files )
-			|| count( self::$deprecated_arguments )
-			|| count( self::$deprecated_constructors )
-		);
+		$total = $this->get_total();
+
+		if ( $total > 0 ) {
+			$this->title( $this->title() . '<span class="debug-bar-issue-count">' . absint( $total ) . '</span>' );
+		}
+	}
+
+	function get_total() {
+		return count( self::$deprecated_functions ) + count( self::$deprecated_files ) + count( self::$deprecated_arguments ) + count( self::$deprecated_constructors );
 	}
 
 	function render() {

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -2,38 +2,52 @@
 // Alot of this code is massaged from Andrew Nacin's log-deprecated-notices plugin
 
 class Debug_Bar_Deprecated extends Debug_Bar_Panel {
-	var $deprecated_functions = array();
-	var $deprecated_files = array();
-	var $deprecated_arguments = array();
+	static $deprecated_functions = array();
+	static $deprecated_files = array();
+	static $deprecated_arguments = array();
+
+	static function start_logging() {
+		add_action( 'deprecated_function_run', array( __CLASS__, 'deprecated_function_run' ), 10, 3 );
+		add_action( 'deprecated_file_included', array( __CLASS__, 'deprecated_file_included' ), 10, 4 );
+		add_action( 'deprecated_argument_run',  array( __CLASS__, 'deprecated_argument_run' ),  10, 3 );
+
+		// Silence E_NOTICE for deprecated usage.
+		foreach ( array( 'function', 'file', 'argument' ) as $item ) {
+			add_filter( "deprecated_{$item}_trigger_error", '__return_false' );
+		}
+	}
+
+	static function stop_logging() {
+		remove_action( 'deprecated_function_run', array( __CLASS__, 'deprecated_function_run' ), 10 );
+		remove_action( 'deprecated_file_included', array( __CLASS__, 'deprecated_file_included' ), 10 );
+		remove_action( 'deprecated_argument_run',  array( __CLASS__, 'deprecated_argument_run' ),  10 );
+
+		// Don't silence E_NOTICE for deprecated usage.
+		foreach ( array( 'function', 'file', 'argument' ) as $item ) {
+			remove_filter( "deprecated_{$item}_trigger_error", '__return_false' );
+		}
+	}
 
 	function init() {
 		$this->title( __('Deprecated', 'debug-bar') );
-
-		add_action( 'deprecated_function_run', array( $this, 'deprecated_function_run' ), 10, 3 );
-		add_action( 'deprecated_file_included', array( $this, 'deprecated_file_included' ), 10, 4 );
-		add_action( 'deprecated_argument_run',  array( $this, 'deprecated_argument_run' ),  10, 3 );
-
-		// Silence E_NOTICE for deprecated usage.
-		foreach ( array( 'function', 'file', 'argument' ) as $item )
-			add_filter( "deprecated_{$item}_trigger_error", '__return_false' );
 	}
 
 	function prerender() {
 		$this->set_visible(
-			count( $this->deprecated_functions )
-			|| count( $this->deprecated_files )
-			|| count( $this->deprecated_arguments )
+			count( self::$deprecated_functions )
+			|| count( self::$deprecated_files )
+			|| count( self::$deprecated_arguments )
 		);
 	}
 
 	function render() {
 		echo "<div id='debug-bar-deprecated'>";
-		echo '<h2><span>', __( 'Total Functions:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->deprecated_functions ) ), "</h2>\n";
-		echo '<h2><span>', __( 'Total Arguments:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->deprecated_arguments ) ), "</h2>\n";
-		echo '<h2><span>', __( 'Total Files:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->deprecated_files ) ), "</h2>\n";
-		if ( count( $this->deprecated_functions ) ) {
+		echo '<h2><span>', __( 'Total Functions:', 'debug-bar' ), '</span>', number_format_i18n( count( self::$deprecated_functions ) ), "</h2>\n";
+		echo '<h2><span>', __( 'Total Arguments:', 'debug-bar' ), '</span>', number_format_i18n( count( self::$deprecated_arguments ) ), "</h2>\n";
+		echo '<h2><span>', __( 'Total Files:', 'debug-bar' ), '</span>', number_format_i18n( count( self::$deprecated_files ) ), "</h2>\n";
+		if ( count( self::$deprecated_functions ) ) {
 			echo '<ol class="debug-bar-deprecated-list">';
-			foreach ( $this->deprecated_functions as $location => $message_stack) {
+			foreach ( self::$deprecated_functions as $location => $message_stack) {
 				list( $message, $stack) = $message_stack;
 				echo "<li class='debug-bar-deprecated-function'>";
 				echo str_replace(ABSPATH, '', $location) . ' - ' . strip_tags($message);
@@ -43,9 +57,9 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			}
 			echo '</ol>';
 		}
-		if ( count( $this->deprecated_files ) ) {
+		if ( count( self::$deprecated_files ) ) {
 			echo '<ol class="debug-bar-deprecated-list">';
-			foreach ( $this->deprecated_files as $location => $message_stack) {
+			foreach ( self::$deprecated_files as $location => $message_stack) {
 				list( $message, $stack) = $message_stack;
 				echo "<li class='debug-bar-deprecated-file'>";
 				echo str_replace(ABSPATH, '', $location) . ' - ' . strip_tags($message);
@@ -55,9 +69,9 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			}
 			echo '</ol>';
 		}
-		if ( count( $this->deprecated_arguments ) ) {
+		if ( count( self::$deprecated_arguments ) ) {
 			echo '<ol class="debug-bar-deprecated-list">';
-			foreach ( $this->deprecated_arguments as $location => $message_stack) {
+			foreach ( self::$deprecated_arguments as $location => $message_stack) {
 				list( $message, $stack) = $message_stack;
 				echo "<li class='debug-bar-deprecated-argument'>";
 				echo str_replace(ABSPATH, '', $location) . ' - ' . strip_tags($message);
@@ -70,7 +84,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		echo "</div>";
 	}
 
-	function deprecated_function_run($function, $replacement, $version) {
+	static function deprecated_function_run($function, $replacement, $version) {
 		$backtrace = debug_backtrace( false );
 		$bt = 4;
 		// Check if we're a hook callback.
@@ -87,10 +101,10 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			$message = sprintf( __('%1$s is <strong>deprecated</strong> since version %2$s with no alternative available.', 'debug-bar'), $function, $version );
 		}
 
-		$this->deprecated_functions[$file.':'.$line] = array( $message, wp_debug_backtrace_summary( null, $bt ) );
+		self::$deprecated_functions[ $file . ':' . $line ] = array( $message, wp_debug_backtrace_summary( null, $bt ) );
 	}
 
-	function deprecated_file_included( $old_file, $replacement, $version, $message ) {
+	static function deprecated_file_included( $old_file, $replacement, $version, $message ) {
 		$backtrace = debug_backtrace( false );
 		$file = $backtrace[4]['file'];
 		$file_abs = str_replace(ABSPATH, '', $file);
@@ -104,13 +118,13 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			$message = sprintf( __('%1$s is <strong>deprecated</strong> since version %2$s with no alternative available.', 'debug-bar'), $file_abs, $version ) . $message;
 		}
 
-		$this->deprecated_files[$file.':'.$line] = array( $message, wp_debug_backtrace_summary( null, 4 ) );
+		self::$deprecated_files[ $file . ':' . $line ] = array( $message, wp_debug_backtrace_summary( null, 4 ) );
 	}
 
-	function deprecated_argument_run( $function, $message, $version) {
+	static function deprecated_argument_run( $function, $message, $version) {
 		$backtrace = debug_backtrace( false );
 		if ( $function === 'define()' ) {
-			$this->deprecated_arguments[] = array( $message, '' );
+			self::$deprecated_arguments[] = array( $message, '' );
 			return;
 		}
 
@@ -126,6 +140,6 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			$message = sprintf( __('%1$s was called with an argument that is <strong>deprecated</strong> since version %2$s with no alternative available.'), $function, $version );
 		}
 
-		$this->deprecated_arguments[$file.':'.$line] = array( $message, wp_debug_backtrace_summary( null, $bt ) );
+		self::$deprecated_arguments[ $file . ':' . $line ] = array( $message, wp_debug_backtrace_summary( null, $bt ) );
 	}
 }

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -98,13 +98,13 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 
 	static function deprecated_function_run($function, $replacement, $version) {
 		$backtrace = debug_backtrace( false );
-		$bt = 4;
+		$bt        = 4;
 		// Check if we're a hook callback.
 		if ( ! isset( $backtrace[4]['file'] ) && 'call_user_func_array' == $backtrace[5]['function'] ) {
 			$bt = 6;
 		}
-		$file = $backtrace[ $bt ]['file'];
-		$line = $backtrace[ $bt ]['line'];
+		$file = ( isset( $backtrace[ $bt ]['file'] ) ? $backtrace[ $bt ]['file'] : 0 );
+		$line = ( isset( $backtrace[ $bt ]['line'] ) ? $backtrace[ $bt ]['line'] : 0 );
 		if ( ! is_null($replacement) ) {
 			/* translators: %1$s is a function or file name, %2$s a version number, %3$s an alternative function or file to use. */
 			$message = sprintf( __('%1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.', 'debug-bar'), $function, $version, $replacement );
@@ -119,9 +119,9 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 
 	static function deprecated_file_included( $old_file, $replacement, $version, $message ) {
 		$backtrace = debug_backtrace( false );
-		$file = $backtrace[4]['file'];
-		$file_abs = str_replace(ABSPATH, '', $file);
-		$line = $backtrace[4]['line'];
+		$file      = $backtrace[4]['file'];
+		$file_abs  = str_replace(ABSPATH, '', $file);
+		$line      = $backtrace[4]['line'];
 		$message = empty( $message ) ? '' : ' ' . $message;
 		if ( ! is_null( $replacement ) ) {
 			/* translators: %1$s is a function or file name, %2$s a version number, %3$s an alternative function or file to use. */
@@ -146,8 +146,8 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		if ( ! isset( $backtrace[4]['file'] ) && 'call_user_func_array' == $backtrace[5]['function'] ) {
 			$bt = 6;
 		}
-		$file = $backtrace[ $bt ]['file'];
-		$line = $backtrace[ $bt ]['line'];
+		$file = ( isset( $backtrace[ $bt ]['file'] ) ? $backtrace[ $bt ]['file'] : 0 );
+		$line = ( isset( $backtrace[ $bt ]['line'] ) ? $backtrace[ $bt ]['line'] : 0 );
 		if ( ! is_null( $message ) ) {
 			$message = sprintf( __('%1$s was called with an argument that is <strong>deprecated</strong> since version %2$s! %3$s'), $function, $version, $message );
 		} else {
@@ -164,8 +164,8 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		if ( ! isset( $backtrace[4]['file'] ) && 'call_user_func_array' == $backtrace[5]['function'] ) {
 			$bt = 6;
 		}
-		$file = $backtrace[ $bt ]['file'];
-		$line = $backtrace[ $bt ]['line'];
+		$file = ( isset( $backtrace[ $bt ]['file'] ) ? $backtrace[ $bt ]['file'] : 0 );
+		$line = ( isset( $backtrace[ $bt ]['line'] ) ? $backtrace[ $bt ]['line'] : 0 );
 
 		if ( ! empty( $parent_class ) ) {
 			/* translators: 1: PHP class name, 2: PHP parent class name, 3: version number, 4: __construct() method */

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -41,47 +41,38 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 	}
 
 	function render() {
-		echo "<div id='debug-bar-deprecated'>";
-		echo '<h2><span>', __( 'Total Functions:', 'debug-bar' ), '</span>', number_format_i18n( count( self::$deprecated_functions ) ), "</h2>\n";
-		echo '<h2><span>', __( 'Total Arguments:', 'debug-bar' ), '</span>', number_format_i18n( count( self::$deprecated_arguments ) ), "</h2>\n";
-		echo '<h2><span>', __( 'Total Files:', 'debug-bar' ), '</span>', number_format_i18n( count( self::$deprecated_files ) ), "</h2>\n";
-		if ( count( self::$deprecated_functions ) ) {
+		echo '<div id="debug-bar-deprecated">';
+
+		$this->render_title( __( 'Total Functions:', 'debug-bar' ), count( self::$deprecated_functions ) );
+		$this->render_title( __( 'Total Files:', 'debug-bar' ), count( self::$deprecated_files ) );
+		$this->render_title( __( 'Total Arguments:', 'debug-bar' ), count( self::$deprecated_arguments ) );
+
+		$this->render_list( self::$deprecated_functions, 'deprecated-function' );
+		$this->render_list( self::$deprecated_files, 'deprecated-file' );
+		$this->render_list( self::$deprecated_arguments, 'deprecated-argument' );
+
+		echo '</div>';
+	}
+
+	function render_title( $title, $count ) {
+		echo '<h2><span>', $title, '</span>', absint( $count ), "</h2>\n";
+	}
+
+	function render_list( $calls, $class ) {
+		if ( count( $calls ) ) {
 			echo '<ol class="debug-bar-deprecated-list">';
-			foreach ( self::$deprecated_functions as $location => $message_stack) {
-				list( $message, $stack) = $message_stack;
-				echo "<li class='debug-bar-deprecated-function'>";
-				echo str_replace(ABSPATH, '', $location) . ' - ' . strip_tags($message);
-				echo "<br/>";
-				echo $stack;
-				echo "</li>";
+			foreach ( $calls as $location => $message_stack ) {
+				list( $message, $stack ) = $message_stack;
+
+				echo '
+				<li class="debug-bar-', $class, '">',
+				str_replace( ABSPATH, '', $location ), ' - ', strip_tags( $message ),
+				'<br/>',
+				$stack,
+				'</li>';
 			}
 			echo '</ol>';
 		}
-		if ( count( self::$deprecated_files ) ) {
-			echo '<ol class="debug-bar-deprecated-list">';
-			foreach ( self::$deprecated_files as $location => $message_stack) {
-				list( $message, $stack) = $message_stack;
-				echo "<li class='debug-bar-deprecated-file'>";
-				echo str_replace(ABSPATH, '', $location) . ' - ' . strip_tags($message);
-				echo "<br/>";
-				echo $stack;
-				echo "</li>";
-			}
-			echo '</ol>';
-		}
-		if ( count( self::$deprecated_arguments ) ) {
-			echo '<ol class="debug-bar-deprecated-list">';
-			foreach ( self::$deprecated_arguments as $location => $message_stack) {
-				list( $message, $stack) = $message_stack;
-				echo "<li class='debug-bar-deprecated-argument'>";
-				echo str_replace(ABSPATH, '', $location) . ' - ' . strip_tags($message);
-				echo "<br/>";
-				echo $stack;
-				echo "</li>";
-			}
-			echo '</ol>';
-		}
-		echo "</div>";
 	}
 
 	static function deprecated_function_run($function, $replacement, $version) {

--- a/panels/class-debug-bar-doingitwrong.php
+++ b/panels/class-debug-bar-doingitwrong.php
@@ -26,7 +26,7 @@ class Debug_Bar_Doing_It_Wrong extends Debug_Bar_Deprecated {
 	function render() {
 		echo '<div id="debug-bar-doingitwrong">';
 		$this->render_title( __( 'Total Calls:', 'debug-bar' ), count( self::$doing_it_wrong ) );
-		$this->render_list( self::$doing_it_wrong, 'doingitwrong' );
+		$this->render_list( self::$doing_it_wrong, 'doingitwrong', __( 'DOING IT WRONG:', 'debug-bar' ) );
 		echo '</div>';
 	}
 

--- a/panels/class-debug-bar-doingitwrong.php
+++ b/panels/class-debug-bar-doingitwrong.php
@@ -1,0 +1,51 @@
+<?php
+
+class Debug_Bar_Doing_It_Wrong extends Debug_Bar_Deprecated {
+
+	static $doing_it_wrong = array();
+
+	static function start_logging() {
+		add_action( 'doing_it_wrong_run', array( __CLASS__, 'doing_it_wrong_run' ), 10, 3 );
+		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+	}
+
+	static function stop_logging() {
+		remove_action( 'doing_it_wrong_run', array( __CLASS__, 'doing_it_wrong_run' ), 10 );
+		remove_filter( 'doing_it_wrong_trigger_error', '__return_false' );
+	}
+
+	function init() {
+		$this->title( __( 'Doing It Wrong', 'debug-bar' ) );
+		$this->set_visible( false );
+	}
+
+	function get_total() {
+		return count( self::$doing_it_wrong );
+	}
+
+	function render() {
+		echo '<div id="debug-bar-doingitwrong">';
+		$this->render_title( __( 'Total Calls:', 'debug-bar' ), count( self::$doing_it_wrong ) );
+		$this->render_list( self::$doing_it_wrong, 'doingitwrong' );
+		echo '</div>';
+	}
+
+	static function doing_it_wrong_run( $function, $message, $version ) {
+		$backtrace = debug_backtrace( false );
+		$bt = 4;
+		if ( ! isset( $backtrace[4]['file'] ) && 'call_user_func_array' == $backtrace[5]['function'] ) {
+			$bt = 6;
+		}
+		$file = $backtrace[ $bt ]['file'];
+		$line = $backtrace[ $bt ]['line'];
+		$version = is_null( $version ) ? '' : sprintf( __( '(This message was added in version %s.)' ), $version );
+		/* translators: %s: Codex URL */
+		$message .= ' ' . sprintf( __( 'Please see <a href="%s">Debugging in WordPress</a> for more information.' ),
+			__( 'https://codex.wordpress.org/Debugging_in_WordPress' )
+		);
+		$notice = sprintf( __( '%1$s was called <strong>incorrectly</strong>. %2$s %3$s' ), $function, $message, $version );
+
+		error_log( $notice );
+		self::$doing_it_wrong[ $file . ':' . $line ] = array( $notice, wp_debug_backtrace_summary( null, $bt ) );
+	}
+}

--- a/panels/class-debug-bar-doingitwrong.php
+++ b/panels/class-debug-bar-doingitwrong.php
@@ -32,12 +32,12 @@ class Debug_Bar_Doing_It_Wrong extends Debug_Bar_Deprecated {
 
 	static function doing_it_wrong_run( $function, $message, $version ) {
 		$backtrace = debug_backtrace( false );
-		$bt = 4;
+		$bt        = 4;
 		if ( ! isset( $backtrace[4]['file'] ) && 'call_user_func_array' == $backtrace[5]['function'] ) {
 			$bt = 6;
 		}
-		$file = $backtrace[ $bt ]['file'];
-		$line = $backtrace[ $bt ]['line'];
+		$file = ( isset( $backtrace[ $bt ]['file'] ) ? $backtrace[ $bt ]['file'] : 0 );
+		$line = ( isset( $backtrace[ $bt ]['line'] ) ? $backtrace[ $bt ]['line'] : 0 );
 		/* translators: %s: version number. */
 		$version = is_null( $version ) ? '' : sprintf( __( '(This message was added in version %s.)' ), $version );
 		/* translators: %s: Codex URL. */

--- a/panels/class-debug-bar-doingitwrong.php
+++ b/panels/class-debug-bar-doingitwrong.php
@@ -38,11 +38,13 @@ class Debug_Bar_Doing_It_Wrong extends Debug_Bar_Deprecated {
 		}
 		$file = $backtrace[ $bt ]['file'];
 		$line = $backtrace[ $bt ]['line'];
+		/* translators: %s: version number. */
 		$version = is_null( $version ) ? '' : sprintf( __( '(This message was added in version %s.)' ), $version );
-		/* translators: %s: Codex URL */
+		/* translators: %s: Codex URL. */
 		$message .= ' ' . sprintf( __( 'Please see <a href="%s">Debugging in WordPress</a> for more information.' ),
 			__( 'https://codex.wordpress.org/Debugging_in_WordPress' )
 		);
+		/* translators: 1: function name, 2: link to more information, 3: version information. */
 		$notice = sprintf( __( '%1$s was called <strong>incorrectly</strong>. %2$s %3$s' ), $function, $message, $version );
 
 		error_log( $notice );

--- a/panels/class-debug-bar-doingitwrong.php
+++ b/panels/class-debug-bar-doingitwrong.php
@@ -26,7 +26,7 @@ class Debug_Bar_Doing_It_Wrong extends Debug_Bar_Deprecated {
 	function render() {
 		echo '<div id="debug-bar-doingitwrong">';
 		$this->render_title( __( 'Total Calls:', 'debug-bar' ), count( self::$doing_it_wrong ) );
-		$this->render_list( self::$doing_it_wrong, 'doingitwrong', __( 'DOING IT WRONG:', 'debug-bar' ) );
+		$this->render_list( self::$doing_it_wrong, __( 'DOING IT WRONG:', 'debug-bar' ), 'doingitwrong' );
 		echo '</div>';
 	}
 

--- a/panels/class-debug-bar-js.php
+++ b/panels/class-debug-bar-js.php
@@ -4,7 +4,7 @@ class Debug_Bar_JS extends Debug_Bar_Panel {
 	var $real_error_handler = array();
 
 	function init() {
-		$this->title( __( 'JavaScript', 'debug-bar' ) . '<span id="debug-bar-js-issue-count" class="debug-bar-issue-count debug-bar-issue-warnings">0</span>' );
+		$this->title( __( 'JavaScript', 'debug-bar' ) . '<span id="debug-bar-js-issue-count">0</span>' );
 
 		// attach here instead of debug_bar_enqueue_scripts
 		// because we want to be as early as possible!

--- a/panels/class-debug-bar-js.php
+++ b/panels/class-debug-bar-js.php
@@ -4,7 +4,7 @@ class Debug_Bar_JS extends Debug_Bar_Panel {
 	var $real_error_handler = array();
 
 	function init() {
-		$this->title( __('JavaScript', 'debug-bar') );
+		$this->title( __( 'JavaScript', 'debug-bar' ) . '<span id="debug-bar-js-issue-count" class="debug-bar-issue-count debug-bar-issue-warnings">0</span>' );
 
 		// attach here instead of debug_bar_enqueue_scripts
 		// because we want to be as early as possible!

--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -1,32 +1,47 @@
 <?php
 
 class Debug_Bar_PHP extends Debug_Bar_Panel {
-	var $warnings = array();
-	var $notices = array();
-	var $real_error_handler = array();
+	static $warnings = array();
+	static $notices = array();
+	static $real_error_handler;
+
+	static function start_logging() {
+		if ( ! WP_DEBUG ) {
+			return false;
+		}
+
+		self::$real_error_handler = set_error_handler( array( __CLASS__, 'error_handler' ) );
+	}
+
+	static function stop_logging() {
+		restore_error_handler();
+	}
 
 	function init() {
 		if ( ! WP_DEBUG )
 			return false;
 
 		$this->title( __('Notices / Warnings', 'debug-bar') );
-
-		$this->real_error_handler = set_error_handler( array( &$this, 'error_handler' ) );
 	}
 
 	function is_visible() {
-		return count( $this->notices ) || count( $this->warnings );
+		return count( self::$notices ) || count( self::$warnings );
 	}
 
 	function debug_bar_classes( $classes ) {
-		if ( count( $this->warnings ) )
+		if ( count( self::$warnings ) ) {
 			$classes[] = 'debug-bar-php-warning-summary';
-		elseif ( count( $this->notices ) )
+		} elseif ( count( self::$notices ) ) {
 			$classes[] = 'debug-bar-php-notice-summary';
+		}
 		return $classes;
 	}
 
-	function error_handler( $type, $message, $file, $line ) {
+	static function error_handler( $type, $message, $file, $line ) {
+		if( ! ( error_reporting() & $type ) ) {
+			return false;
+		}
+
 		$_key = md5( $file . ':' . $line . ':' . $message );
 
 		if ( ! defined( 'E_DEPRECATED' ) ) {
@@ -39,11 +54,11 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 		switch ( $type ) {
 			case E_WARNING :
 			case E_USER_WARNING :
-				$this->warnings[$_key] = array( $file.':'.$line, $message, wp_debug_backtrace_summary( __CLASS__ ) );
+				self::$warnings[$_key] = array( $file.':'.$line, $message, wp_debug_backtrace_summary( __CLASS__ ) );
 				break;
 			case E_NOTICE :
 			case E_USER_NOTICE :
-				$this->notices[$_key] = array( $file.':'.$line, $message, wp_debug_backtrace_summary( __CLASS__ ) );
+				self::$notices[$_key] = array( $file.':'.$line, $message, wp_debug_backtrace_summary( __CLASS__ ) );
 				break;
 			case E_STRICT :
 				// TODO
@@ -57,19 +72,20 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 				break;
 		}
 
-		if ( null != $this->real_error_handler )
-			return call_user_func( $this->real_error_handler, $type, $message, $file, $line );
-		else
+		if ( isset( self::$real_error_handler ) ) {
+			return call_user_func( self::$real_error_handler, $type, $message, $file, $line );
+		} else {
 			return false;
+		}
 	}
 
 	function render() {
 		echo "<div id='debug-bar-php'>";
-		echo '<h2><span>', __( 'Total Warnings:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->warnings ) ), "</h2>\n";
-		echo '<h2><span>', __( 'Total Notices:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->notices ) ), "</h2>\n";
-		if ( count( $this->warnings ) ) {
+		echo '<h2><span>', __( 'Total Warnings:', 'debug-bar' ), '</span>', number_format_i18n( count( self::$warnings ) ), "</h2>\n";
+		echo '<h2><span>', __( 'Total Notices:', 'debug-bar' ), '</span>', number_format_i18n( count( self::$notices ) ), "</h2>\n";
+		if ( count( self::$warnings ) ) {
 			echo '<ol class="debug-bar-php-list">';
-			foreach ( $this->warnings as $location_message_stack ) {
+			foreach ( self::$warnings as $location_message_stack ) {
 				list( $location, $message, $stack) = $location_message_stack;
 				echo '<li class="debug-bar-php-warning">', __( 'WARNING:', 'debug-bar' ), ' ';
 				echo str_replace(ABSPATH, '', $location) . ' - ' . strip_tags($message);
@@ -79,9 +95,9 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 			}
 			echo '</ol>';
 		}
-		if ( count( $this->notices ) ) {
+		if ( count( self::$notices ) ) {
 			echo '<ol class="debug-bar-php-list">';
-			foreach ( $this->notices as $location_message_stack) {
+			foreach ( self::$notices as $location_message_stack) {
 				list( $location, $message, $stack) = $location_message_stack;
 				echo '<li class="debug-bar-php-notice">', __( 'NOTICE:', 'debug-bar' ), ' ';
 				echo str_replace(ABSPATH, '', $location) . ' - ' . strip_tags($message);

--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -1,8 +1,11 @@
 <?php
 
 class Debug_Bar_PHP extends Debug_Bar_Panel {
-	static $warnings = array();
-	static $notices = array();
+	static $warnings   = array();
+	static $notices    = array();
+	static $strict     = array();
+	static $deprecated = array();
+	static $silenced   = array();
 	static $real_error_handler;
 
 	static function start_logging() {
@@ -40,51 +43,41 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 	}
 
 	function get_total() {
-		return count( self::$notices ) + count( self::$warnings );
+		return count( self::$notices ) + count( self::$warnings ) + count( self::$strict ) + count( self::$deprecated ) + count( self::$silenced );
 	}
 
 	function debug_bar_classes( $classes ) {
 		if ( count( self::$warnings ) ) {
 			$classes[] = 'debug-bar-warning-summary';
-		} elseif ( count( self::$notices ) ) {
+		} elseif ( $this->get_total() ) {
 			$classes[] = 'debug-bar-notice-summary';
 		}
 		return $classes;
 	}
 
 	static function error_handler( $type, $message, $file, $line ) {
-		if( ! ( error_reporting() & $type ) ) {
-			return false;
-		}
-
 		$_key = md5( $file . ':' . $line . ':' . $message );
 
-		if ( ! defined( 'E_DEPRECATED' ) ) {
-			define( 'E_DEPRECATED', 8192 );
-		}
-		if ( ! defined( 'E_USER_DEPRECATED' ) )	{
-			define( 'E_USER_DEPRECATED', 16384 );
-		}
-
-		switch ( $type ) {
-			case E_WARNING :
-			case E_USER_WARNING :
-				self::$warnings[$_key] = array( $file.':'.$line, $message, wp_debug_backtrace_summary( __CLASS__ ) );
-				break;
-			case E_NOTICE :
-			case E_USER_NOTICE :
-				self::$notices[$_key] = array( $file.':'.$line, $message, wp_debug_backtrace_summary( __CLASS__ ) );
-				break;
-			case E_STRICT :
-				// TODO
-				break;
-			case E_DEPRECATED :
-			case E_USER_DEPRECATED :
-				// TODO
-				break;
-			case 0 :
-				// TODO
-				break;
+		if ( 0 === error_reporting() ) {
+			self::$silenced[ $_key ] = array( $file . ':' . $line, $message, wp_debug_backtrace_summary( __CLASS__ ) );
+		} else {
+			switch ( $type ) {
+				case E_WARNING :
+				case E_USER_WARNING :
+					self::$warnings[ $_key ] = array( $file . ':' . $line, $message, wp_debug_backtrace_summary( __CLASS__ ) );
+					break;
+				case E_NOTICE :
+				case E_USER_NOTICE :
+					self::$notices[ $_key ] = array( $file . ':' . $line, $message, wp_debug_backtrace_summary( __CLASS__ ) );
+					break;
+				case E_STRICT :
+					self::$strict[ $_key ] = array( $file . ':' . $line, $message, wp_debug_backtrace_summary( __CLASS__ ) );
+					break;
+				case E_DEPRECATED :
+				case E_USER_DEPRECATED :
+					self::$deprecated[ $_key ] = array( $file . ':' . $line, $message, wp_debug_backtrace_summary( __CLASS__ ) );
+					break;
+			}
 		}
 
 		if ( isset( self::$real_error_handler ) ) {
@@ -99,9 +92,15 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 
 		$this->render_title ( __( 'Total Warnings:', 'debug-bar' ), count( self::$warnings ) );
 		$this->render_title ( __( 'Total Notices:', 'debug-bar' ), count( self::$notices ) );
+		$this->render_title ( __( 'Total Strict Notices:', 'debug-bar' ), count( self::$strict ) );
+		$this->render_title ( __( 'Total Deprecated:', 'debug-bar' ), count( self::$deprecated ) );
+		$this->render_title ( __( 'Total Silenced:', 'debug-bar' ), count( self::$silenced ) );
 
 		$this->render_list( self::$warnings, __( 'WARNING:', 'debug-bar' ), 'warning' );
 		$this->render_list( self::$notices, __( 'NOTICE:', 'debug-bar' ), 'notice' );
+		$this->render_list( self::$strict, __( 'STRICT:', 'debug-bar' ), 'notice' );
+		$this->render_list( self::$deprecated, __( 'DEPRECATED:', 'debug-bar' ), 'notice' );
+		$this->render_list( self::$silenced, __( 'SILENCED:', 'debug-bar' ), 'warning' );
 
 		echo '</div>';
 	}

--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -45,9 +45,9 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 
 	function debug_bar_classes( $classes ) {
 		if ( count( self::$warnings ) ) {
-			$classes[] = 'debug-bar-php-warning-summary';
+			$classes[] = 'debug-bar-warning-summary';
 		} elseif ( count( self::$notices ) ) {
-			$classes[] = 'debug-bar-php-notice-summary';
+			$classes[] = 'debug-bar-notice-summary';
 		}
 		return $classes;
 	}

--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -18,14 +18,29 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 	}
 
 	function init() {
-		if ( ! WP_DEBUG )
+		if ( ! WP_DEBUG ) {
 			return false;
+		}
 
 		$this->title( __('Notices / Warnings', 'debug-bar') );
+		$this->set_visible( false );
 	}
 
 	function is_visible() {
-		return count( self::$notices ) || count( self::$warnings );
+		return ( $this->get_total() > 0 );
+	}
+
+	function prerender() {
+		$total = $this->get_total();
+
+		if ( $total > 0 ) {
+			$warnings = ( count( self::$warnings ) > 0 ? ' debug-bar-issue-warnings' : '' );
+			$this->title( $this->title() . '<span class="debug-bar-issue-count' . $warnings . '">' . absint( $total ) . '</span>' );
+		}
+	}
+
+	function get_total() {
+		return count( self::$notices ) + count( self::$warnings );
 	}
 
 	function debug_bar_classes( $classes ) {

--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -13,6 +13,7 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 			return false;
 		}
 
+		error_reporting( -1 );
 		self::$real_error_handler = set_error_handler( array( __CLASS__, 'error_handler' ) );
 	}
 
@@ -56,6 +57,7 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 	}
 
 	static function error_handler( $type, $message, $file, $line ) {
+
 		$_key = md5( $file . ':' . $line . ':' . $message );
 
 		if ( 0 === error_reporting() ) {

--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -61,6 +61,14 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 		if ( 0 === error_reporting() ) {
 			self::$silenced[ $_key ] = array( $file . ':' . $line, $message, wp_debug_backtrace_summary( __CLASS__ ) );
 		} else {
+
+			if ( ! defined( 'E_DEPRECATED' ) ) {
+				define( 'E_DEPRECATED', 8192 );
+			}
+			if ( ! defined( 'E_USER_DEPRECATED' ) )	{
+				define( 'E_USER_DEPRECATED', 16384 );
+			}
+
 			switch ( $type ) {
 				case E_WARNING :
 				case E_USER_WARNING :

--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -80,35 +80,35 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 	}
 
 	function render() {
-		echo "<div id='debug-bar-php'>";
-		echo '<h2><span>', __( 'Total Warnings:', 'debug-bar' ), '</span>', number_format_i18n( count( self::$warnings ) ), "</h2>\n";
-		echo '<h2><span>', __( 'Total Notices:', 'debug-bar' ), '</span>', number_format_i18n( count( self::$notices ) ), "</h2>\n";
-		if ( count( self::$warnings ) ) {
-			echo '<ol class="debug-bar-php-list">';
-			foreach ( self::$warnings as $location_message_stack ) {
-				list( $location, $message, $stack) = $location_message_stack;
-				echo '<li class="debug-bar-php-warning">', __( 'WARNING:', 'debug-bar' ), ' ';
-				echo str_replace(ABSPATH, '', $location) . ' - ' . strip_tags($message);
-				echo '<br/>';
-				echo $stack;
-				echo '</li>';
-			}
-			echo '</ol>';
-		}
-		if ( count( self::$notices ) ) {
-			echo '<ol class="debug-bar-php-list">';
-			foreach ( self::$notices as $location_message_stack) {
-				list( $location, $message, $stack) = $location_message_stack;
-				echo '<li class="debug-bar-php-notice">', __( 'NOTICE:', 'debug-bar' ), ' ';
-				echo str_replace(ABSPATH, '', $location) . ' - ' . strip_tags($message);
-				echo '<br/>';
-				echo $stack;
-				echo '</li>';
-			}
-			echo '</ol>';
-		}
-		echo "</div>";
+		echo '<div id="debug-bar-php">';
 
+		$this->render_title ( __( 'Total Warnings:', 'debug-bar' ), count( self::$warnings ) );
+		$this->render_title ( __( 'Total Notices:', 'debug-bar' ), count( self::$notices ) );
+
+		$this->render_list( self::$warnings, __( 'WARNING:', 'debug-bar' ), 'warning' );
+		$this->render_list( self::$notices, __( 'NOTICE:', 'debug-bar' ), 'notice' );
+
+		echo '</div>';
+	}
+
+	function render_title ( $title, $count ) {
+		echo '<h2><span>', $title, '</span>', absint( $count ), "</h2>\n";
+	}
+
+	function render_list( $errors, $line_prefix, $class ) {
+		if ( count( $errors ) ) {
+			echo '<ol class="debug-bar-php-list">';
+			foreach ( $errors as $location_message_stack ) {
+				list( $location, $message, $stack ) = $location_message_stack;
+
+				echo '
+				<li class="debug-bar-php-', $class ,'">', $line_prefix, ' ',
+				str_replace( ABSPATH, '', $location ), ' - ', strip_tags( $message ),
+				'<br/>',
+				$stack,
+				'</li>';
+			}
+			echo '</ol>';
+		}
 	}
 }
-

--- a/panels/class-debug-bar-queries.php
+++ b/panels/class-debug-bar-queries.php
@@ -11,7 +11,7 @@ class Debug_Bar_Queries extends Debug_Bar_Panel {
 
 	function debug_bar_classes( $classes ) {
 		if ( ! empty($GLOBALS['EZSQL_ERROR']) )
-			$classes[] = 'debug-bar-php-warning-summary';
+			$classes[] = 'debug-bar-warning-summary';
 		return $classes;
 	}
 


### PR DESCRIPTION
This is the big one. Please see the individual commit message for more details.

Changes includes:
- [Bugfix] PHP Error logging was only started when the admin bar was initialized which meant it did not catch nor show any errors generated before that point.
- [Bugfix] Deprecated notice logging was only started when the admin bar was initialized which meant it did not catch nor show any errors generated before that point.
- [Bugfix] Fix some error notices for PHP 5.2.
- [Enhancement] Added logging of PHP strict, deprecated and silenced error notices to the PHP panel.
- [Enhancement] Added logging of deprecated constructors to the deprecated panel.
- [Enhancement] Add a new panel showing 'doing it wrong' notices.
- [Enhancement] Even though display of deprecated/doing it wrong and other notices is not send to the screen - as they are displayed in their respective debug bar panels instead -, _do_ continue to send them to the error log if one has been set up.
- [Enhancement] Improve usability by showing error counts in the panel menu for PHP/Deprecated/JS/Doing It Wrong.
- [Enhancement] Improve usability by colourizing the button in the admin bar late. This allows for the button to show there are warning or notices even after the button was created.
- [Enhancement] Improve usability by also colourizing the button in the admin bar for Deprecated/Doing it Wrong notices.
- Minor refactoring
