### PR TITLE
Don't show E_USER_DEPRECATED in the PHP Panel  …

### DIFF
--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -60,7 +60,6 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 				// TODO
 				break;
 			case E_DEPRECATED:
-			case E_USER_DEPRECATED:
 				// TODO
 				break;
 			case 0:


### PR DESCRIPTION
…as they should show in the Deprecated panel.

This removes duplicates of these notices from the PHP Panel. However it is presumed that devs use the appropriate WP `_deprecated_...()` function call.

Removing this constant here will does mean that when an error is throw with this level without using the WP function, it will not show up at all.

**Note**: This patch should only be merged once the related (open) core patch https://core.trac.wordpress.org/ticket/36561 has been merged in.
