### PR TITLE
Prevent fatal errors when calling `_deprecated_constructor()`.

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -28,7 +28,9 @@ class Debug_Bar {
 	}
 
 	function Debug_Bar() {
-		_deprecated_constructor( __METHOD__, '0.8.3', __CLASS__ );
+		if ( function_exists( '_deprecated_constructor' ) ) {
+			_deprecated_constructor( __METHOD__, '0.8.3', __CLASS__ );
+		}
 		self::__construct();
 	}
 

--- a/panels/class-debug-bar-panel.php
+++ b/panels/class-debug-bar-panel.php
@@ -17,7 +17,9 @@ class Debug_Bar_Panel {
 	}
 
 	function Debug_Bar_Panel( $title = '' ) {
-		_deprecated_constructor( __METHOD__, '0.8.3', __CLASS__ );
+		if ( function_exists( '_deprecated_constructor' ) ) {
+			_deprecated_constructor( __METHOD__, '0.8.3', __CLASS__ );
+		}
 		self::__construct( $title );
 	}
 


### PR DESCRIPTION
`_deprecated_constructor()` was introduced in WP 4.3.
