### PR TITLE
Minor fixes to the 0.9 release

### DIFF
--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -129,9 +129,11 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		$location = $backtrace[ $bt ]['file'] . ':' . $backtrace[ $bt ]['line'];
 
 		if ( ! is_null( $message ) ) {
-			$message = sprintf( __( '%1$s was called with an argument that is <strong>deprecated</strong> since version %2$s! %3$s' ), $function, $version, $message );
+			/* translators: %1$s is a function name, %2$s a version number, %3$s a message regarding the change. */
+			$message = sprintf( __( '%1$s was called with an argument that is <strong>deprecated</strong> since version %2$s! %3$s', 'debug-bar' ), $function, $version, $message );
 		} else {
-			$message = sprintf( __( '%1$s was called with an argument that is <strong>deprecated</strong> since version %2$s with no alternative available.' ), $function, $version );
+			/* translators: %1$s is a function name, %2$s a version number. */
+			$message = sprintf( __( '%1$s was called with an argument that is <strong>deprecated</strong> since version %2$s with no alternative available.', 'debug-bar' ), $function, $version );
 		}
 
 		$this->deprecated_arguments[ $location ] = array( $message, wp_debug_backtrace_summary( null, $bt ) );

--- a/panels/class-debug-bar-js.php
+++ b/panels/class-debug-bar-js.php
@@ -11,7 +11,7 @@ class Debug_Bar_JS extends Debug_Bar_Panel {
 		 * because we want to be as early as possible!
 		 */
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.dev' : '';
-		wp_enqueue_script( 'debug-bar-js', plugins_url( "js/debug-bar-js$suffix.js", dirname( __FILE__ ) ), array( 'jquery' ), '20111216' );
+		wp_enqueue_script( 'debug-bar-js', plugins_url( "js/debug-bar-js$suffix.js", dirname( __FILE__ ) ), array( 'jquery' ), '20170515' );
 	}
 
 	function render() {

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,7 @@ There are numerous other add-ons available to get more insight into, for instanc
 = 0.9 =
 Added panel navigation to toolbar.
 Improved localization support.
+Lots of bug fixes.
 Security fixes.
 
 = 0.8.4 =
@@ -95,9 +96,22 @@ Initial Release
 == Changelog ==
 
 = 0.9 =
-Added panel navigation to toolbar.
-Improved localization support.
-Security fixes.
+* [Enhancement] Added panel navigation to toolbar.
+* [Enhancement] Introduced a `debug_bar_enable` filter which allows for selectively giving access to the debug bar for additional users, such as site-admins in a multi-site environment.
+* [Enhancement] Improved readability of the WP Query - Queried object information.
+* [Enhancement] Allow for large(r) number of add-ons in the panel menu.
+* [Enhancement] The Debug bar plugin is now fully translatable. If you'd like to translate the plugin to your own language, head on over to [GlotPress](https://translate.wordpress.org/projects/wp-plugins/debug-bar).
+* [Bugfix] Security fixes.
+* [Bugfix] Added the missing message text for deprecated arguments.
+* [Bugfix] Fixed the classification of the various deprecated notices - previously all would be seen as functions.
+* [Bugfix] Prevent things looking weird when the current locale is RTL based.
+* [Bugfix] Diminish bleed through of front-end CSS styling.
+* [Bugfix] Add missing `jquery` dependency when loading scripts.
+* [Bugfix] Fix some error notices for PHP 5.2.
+* [Bugfix] Fix an HTML error (incorrect nesting).
+* Improved help information in the readme.
+* Minor refactoring.
+* Minimum WP version is now WP 3.4.
 
 = 0.8.4 =
 Updated to avoid incompatibilities with some extensions.


### PR DESCRIPTION
* Updated the changelog for all the other changes
* One changed js script did not have its version number changed, potentially creating issues caused by the browser still serving an old version from the cache.
* Two strings missing text-domain and translators comment.

/cc @obenland