### PR TITLE
Finish off code style fixes.

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -62,7 +62,7 @@ class Debug_Bar {
 	 * @return bool
 	 */
 	function is_wp_login() {
-		return 'wp-login.php' == basename( $_SERVER['SCRIPT_NAME'] );
+		return 'wp-login.php' === basename( $_SERVER['SCRIPT_NAME'] );
 	}
 
 	/**
@@ -138,7 +138,8 @@ class Debug_Bar {
 		$this->panels = apply_filters( 'debug_bar_panels', $this->panels );
 	}
 
-	function ensure_ajaxurl() { ?>
+	function ensure_ajaxurl() {
+		?>
 		<script type="text/javascript">
 			//<![CDATA[
 			var ajaxurl = '<?php echo admin_url( 'admin-ajax.php' ); ?>';
@@ -156,14 +157,16 @@ class Debug_Bar {
 		global $wp_admin_bar;
 
 		$classes = apply_filters( 'debug_bar_classes', array() );
-		$classes = implode( " ", $classes );
+		$classes = implode( ' ', $classes );
 
 		/* Add the main siteadmin menu item */
 		$wp_admin_bar->add_menu( array(
 			'id'     => 'debug-bar',
 			'parent' => 'top-secondary',
 			'title'  => apply_filters( 'debug_bar_title', __( 'Debug', 'debug-bar' ) ),
-			'meta'   => array( 'class' => $classes ),
+			'meta'   => array(
+				'class' => $classes,
+			),
 		) );
 
 		foreach ( $this->panels as $panel_key => $panel ) {
@@ -229,7 +232,8 @@ class Debug_Bar {
 
 			<div id='debug-bar-info'>
 				<div id="debug-status">
-					<?php //@todo: Add a links to information about WP_DEBUG, PHP version, MySQL version, and Peak Memory.
+					<?php
+					//@todo: Add a links to information about WP_DEBUG, PHP version, MySQL version, and Peak Memory.
 					$statuses   = array();
 					$statuses[] = array(
 						'site',
@@ -265,16 +269,20 @@ class Debug_Bar {
 
 					$statuses = apply_filters( 'debug_bar_statuses', $statuses );
 
-					foreach ( $statuses as $status ):
+					foreach ( $statuses as $status ) :
 						list( $slug, $title, $data ) = $status;
-
 						?>
 						<div id='debug-status-<?php echo esc_attr( $slug ); ?>' class='debug-status'>
 						<div class='debug-status-title'><?php echo $title; ?></div>
-						<?php if ( ! empty( $data ) ): ?>
+						<?php
+						if ( ! empty( $data ) ) :
+						?>
 						<div class='debug-status-data'><?php echo $data; ?></div>
-					<?php endif; ?>
-						</div><?php
+						<?php
+						endif;
+						?>
+						</div>
+						<?php
 					endforeach;
 					?>
 				</div>
@@ -299,18 +307,21 @@ class Debug_Bar {
 							</a></li>
 						<?php
 						$current = '';
-					endforeach; ?>
-
+					endforeach;
+					?>
 				</ul>
 			</div>
 
-			<div id="debug-menu-targets"><?php
+			<div id="debug-menu-targets">
+				<?php
 				$current = ' style="display: block"';
 				foreach ( $this->panels as $panel ) :
-					$class = get_class( $panel ); ?>
-
+					$class = get_class( $panel );
+					?>
 					<div id="debug-menu-target-<?php echo $class; ?>" class="debug-menu-target" <?php echo $current; ?>>
-						<?php $panel->render(); ?>
+						<?php
+						$panel->render();
+						?>
 					</div>
 
 					<?php

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -29,7 +29,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 	}
 
 	function render() {
-		echo "<div id='debug-bar-deprecated'>";
+		echo '<div id="debug-bar-deprecated">';
 		echo '<h2><span>', __( 'Total Functions:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->deprecated_functions ) ), "</h2>\n";
 		echo '<h2><span>', __( 'Total Arguments:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->deprecated_arguments ) ), "</h2>\n";
 		echo '<h2><span>', __( 'Total Files:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->deprecated_files ) ), "</h2>\n";
@@ -37,11 +37,11 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			echo '<ol class="debug-bar-deprecated-list">';
 			foreach ( $this->deprecated_functions as $location => $message_stack ) {
 				list( $message, $stack ) = $message_stack;
-				echo "<li class='debug-bar-deprecated-function'>";
+				echo '<li class="debug-bar-deprecated-function">';
 				echo str_replace( ABSPATH, '', $location ) . ' - ' . strip_tags( $message );
-				echo "<br/>";
+				echo '<br/>';
 				echo $stack;
-				echo "</li>";
+				echo '</li>';
 			}
 			echo '</ol>';
 		}
@@ -49,11 +49,11 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			echo '<ol class="debug-bar-deprecated-list">';
 			foreach ( $this->deprecated_files as $location => $message_stack ) {
 				list( $message, $stack ) = $message_stack;
-				echo "<li class='debug-bar-deprecated-file'>";
+				echo '<li class="debug-bar-deprecated-file">';
 				echo str_replace( ABSPATH, '', $location ) . ' - ' . strip_tags( $message );
-				echo "<br/>";
+				echo '<br/>';
 				echo $stack;
-				echo "</li>";
+				echo '</li>';
 			}
 			echo '</ol>';
 		}
@@ -61,15 +61,15 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			echo '<ol class="debug-bar-deprecated-list">';
 			foreach ( $this->deprecated_arguments as $location => $message_stack ) {
 				list( $message, $stack ) = $message_stack;
-				echo "<li class='debug-bar-deprecated-argument'>";
+				echo '<li class="debug-bar-deprecated-argument">';
 				echo str_replace( ABSPATH, '', $location ) . ' - ' . strip_tags( $message );
-				echo "<br/>";
+				echo '<br/>';
 				echo $stack;
-				echo "</li>";
+				echo '</li>';
 			}
 			echo '</ol>';
 		}
-		echo "</div>";
+		echo '</div>';
 	}
 
 	function deprecated_function_run( $function, $replacement, $version ) {
@@ -77,7 +77,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		$bt        = 4;
 
 		// Check if we're a hook callback.
-		if ( ! isset( $backtrace[4]['file'] ) && 'call_user_func_array' == $backtrace[5]['function'] ) {
+		if ( ! isset( $backtrace[4]['file'] ) && 'call_user_func_array' === $backtrace[5]['function'] ) {
 			$bt = 6;
 		}
 
@@ -122,7 +122,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		}
 
 		$bt = 4;
-		if ( ! isset( $backtrace[4]['file'] ) && 'call_user_func_array' == $backtrace[5]['function'] ) {
+		if ( ! isset( $backtrace[4]['file'] ) && 'call_user_func_array' === $backtrace[5]['function'] ) {
 			$bt = 6;
 		}
 

--- a/panels/class-debug-bar-object-cache.php
+++ b/panels/class-debug-bar-object-cache.php
@@ -14,9 +14,9 @@ class Debug_Bar_Object_Cache extends Debug_Bar_Panel {
 		global $wp_object_cache;
 
 		ob_start();
-		echo "<div id='object-cache-stats'>";
+		echo '<div id="object-cache-stats">';
 		$wp_object_cache->stats();
-		echo "</div>";
+		echo '</div>';
 		$out = ob_get_contents();
 		ob_end_clean();
 

--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -68,7 +68,7 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 				break;
 		}
 
-		if ( null != $this->real_error_handler ) {
+		if ( null !== $this->real_error_handler ) {
 			return call_user_func( $this->real_error_handler, $type, $message, $file, $line );
 		} else {
 			return false;
@@ -76,7 +76,7 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 	}
 
 	function render() {
-		echo "<div id='debug-bar-php'>";
+		echo '<div id="debug-bar-php">';
 		echo '<h2><span>', __( 'Total Warnings:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->warnings ) ), "</h2>\n";
 		echo '<h2><span>', __( 'Total Notices:', 'debug-bar' ), '</span>', number_format_i18n( count( $this->notices ) ), "</h2>\n";
 
@@ -106,6 +106,6 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 			echo '</ol>';
 		}
 
-		echo "</div>";
+		echo '</div>';
 	}
 }

--- a/panels/class-debug-bar-queries.php
+++ b/panels/class-debug-bar-queries.php
@@ -29,7 +29,7 @@ class Debug_Bar_Queries extends Debug_Bar_Panel {
 
 			if ( $wpdb->num_queries > 500 && ! $show_many ) {
 				/* translators: %s = a url. */
-				$out .= "<p>" . sprintf( __( 'There are too many queries to show easily! <a href="%s">Show them anyway</a>', 'debug-bar' ), esc_url( add_query_arg( 'debug_queries', 'true' ) ) ) . "</p>";
+				$out .= '<p>' . sprintf( __( 'There are too many queries to show easily! <a href="%s">Show them anyway</a>', 'debug-bar' ), esc_url( add_query_arg( 'debug_queries', 'true' ) ) ) . '</p>';
 			}
 
 			$out .= '<ol class="wpd-queries">';
@@ -57,10 +57,10 @@ class Debug_Bar_Queries extends Debug_Bar_Panel {
 				$out .= "<li>$query<br/><div class='qdebug'>$debug <span>#$counter ($time)</span></div></li>\n";
 			}
 			$out .= '</ol>';
-		} else if ( 0 === $wpdb->num_queries ) {
-			$out .= "<p><strong>" . __( 'There are no queries on this page.', 'debug-bar' ) . "</strong></p>";
+		} elseif ( 0 === $wpdb->num_queries ) {
+			$out .= '<p><strong>' . __( 'There are no queries on this page.', 'debug-bar' ) . '</strong></p>';
 		} else {
-			$out .= "<p><strong>" . __( 'SAVEQUERIES must be defined to show the query log.', 'debug-bar' ) . "</strong></p>";
+			$out .= '<p><strong>' . __( 'SAVEQUERIES must be defined to show the query log.', 'debug-bar' ) . '</strong></p>';
 		}
 
 		if ( ! empty( $EZSQL_ERROR ) ) {

--- a/panels/class-debug-bar-request.php
+++ b/panels/class-debug-bar-request.php
@@ -2,7 +2,7 @@
 
 class Debug_Bar_Request extends Debug_Bar_Panel {
 	function init() {
-		$this->title( __('Request', 'debug-bar') );
+		$this->title( __( 'Request', 'debug-bar' ) );
 	}
 
 	function prerender() {
@@ -12,7 +12,7 @@ class Debug_Bar_Request extends Debug_Bar_Panel {
 	function render() {
 		global $wp;
 
-		echo "<div id='debug-bar-request'>";
+		echo '<div id="debug-bar-request">';
 
 		if ( empty( $wp->request ) ) {
 			$request = __( 'None', 'debug-bar' );

--- a/panels/class-debug-bar-wp-query.php
+++ b/panels/class-debug-bar-wp-query.php
@@ -17,7 +17,7 @@ class Debug_Bar_WP_Query extends Debug_Bar_Panel {
 			$post_type_object = get_post_type_object( $queried_object->post_type );
 		}
 
-		echo "<div id='debug-bar-wp-query'>";
+		echo '<div id="debug-bar-wp-query">';
 		echo '<h2><span>', __( 'Queried Object ID:', 'debug-bar' ), '</span>', (int) get_queried_object_id(), "</h2>\n";
 
 		// Determine the query type. Follows the template loader order.
@@ -65,7 +65,7 @@ class Debug_Bar_WP_Query extends Debug_Bar_Panel {
 		$page_for_posts = get_option( 'page_for_posts' );
 
 		echo '<h2><span>', __( 'Show on Front:', 'debug-bar' ), '</span>', $show_on_front, "</h2>\n";
-		if ( 'page' == $show_on_front ) {
+		if ( 'page' === $show_on_front ) {
 			echo '<h2><span>', __( 'Page for Posts:', 'debug-bar' ), '</span>', $page_for_posts, "</h2>\n";
 			echo '<h2><span>', __( 'Page on Front:', 'debug-bar' ), '</span>', $page_on_front, "</h2>\n";
 		}


### PR DESCRIPTION
I noticed that the last commits before the 0.9 release contained quite some code style fixes.
As the code is now close to complying with the WP Extra rules, we might as well go all the way.

This PR contains the minimal changes needed to comply with the `WordPress-Extra` WPCS ruleset with the exception of two rules which will be so annotated in the ruleset (to be pulled in a separate PR).

/cc @obenland