### PR TITLE
Set up basic quality control

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,3 @@
+{
+    "preset": "wordpress"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,77 @@
+# Travis CI (MIT License) configuration file
+# @link https://travis-ci.org/
+
+# Use new container based environment
+sudo: false
+
+# Declare project language.
+# @link http://about.travis-ci.org/docs/user/languages/php/
+language: php
+
+# Declare versions of PHP to use. Use one decimal max.
+matrix:
+  fast_finish: true
+
+  include:
+    # aliased to 5.2.17
+    - php: '5.2'
+    # aliased to 5.3.29
+    - php: '5.3'
+    # aliased to a recent 5.4.x version
+    - php: '5.4'
+    # aliased to a recent 5.5.x version
+    - php: '5.5'
+    # aliased to a recent 5.6.x version
+    - php: '5.6'
+      env: SNIFF=1
+    # aliased to a recent 7.0.x version
+    - php: '7.0'
+    # aliased to a recent 7.1.x version
+    - php: '7.1'
+    # bleeding edge PHP
+    - php: 'nightly'
+
+  allow_failures:
+    - php: 'nightly'
+
+before_script:
+    - export PHPCS_DIR=/tmp/phpcs
+    - export SNIFFS_DIR=/tmp/sniffs
+    # Install CodeSniffer for WordPress Coding Standards checks.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b 2.9 --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
+    # Install WordPress Coding Standards.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b develop --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+    # Install PHP Compatibility sniffs.
+    # @TODO ADJUST PATH FOR Composer PR when merged!
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
+    # Set install path for PHPCS sniffs.
+    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
+    # After CodeSniffer install you should refresh your path.
+    - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
+    # Install JSCS: JavaScript Code Style checker.
+    # @link http://jscs.info/
+    - if [[ "$SNIFF" == "1" ]]; then npm install -g jscs; fi
+    # Install JSHint, a JavaScript Code Quality Tool.
+    # @link http://jshint.com/docs/
+    - if [[ "$SNIFF" == "1" ]]; then npm install -g jshint; fi
+    # Pull in the WP Core jshint rules.
+    - if [[ "$SNIFF" == "1" ]]; then wget https://develop.svn.wordpress.org/trunk/.jshintrc; fi
+
+# Run test script commands.
+# All commands must exit with code 0 on success. Anything else is considered failure.
+script:
+    # Search for PHP syntax errors.
+    - find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+    # Run the plugin through JSHint.
+    - if [[ "$SNIFF" == "1" ]]; then jshint ./js/*.dev.js; fi
+    # Run the plugin through JavaScript Code Style checker.
+    - if [[ "$SNIFF" == "1" ]]; then jscs ./js/*.dev.js; fi
+    # Check code against the WordPress Coding Standards and for PHP cross-version compatibility.
+    # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+    # @link http://github.com/wimg/phpcompatibility
+    # @link http://pear.php.net/package/PHP_CodeSniffer/
+    # Uses a custom ruleset based on WordPress. This ruleset is automatically
+    # picked up by PHPCS as it's named `phpcs.xml(.dist)`.
+    # Only fails the build on errors, not warnings, but still show warnings in the output.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --runtime-set ignore_warnings_on_exit 1; fi

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<ruleset name="Debug Bar">
+	<description>The code standard for Debug Bar is WordPress.</description>
+
+	<!-- Pass some flags to PHPCS:
+		 p flag: Show progress of the run.
+		 s flag: Show sniff codes in all reports.
+		 v flag: Print verbose output.
+		 n flag: Do not print warnings.
+	-->
+	<arg value="ps"/>
+
+	<!-- Only check the PHP files. JS files are checked separately with JSCS and JSHint. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Check all files in this directory and the directories below it. -->
+	<file>.</file>
+
+	<!-- ##### PHP cross-version compatibility ##### -->
+	<config name="testVersion" value="5.2-99.0"/>
+	<rule ref="PHPCompatibility">
+		<!-- We can ignore this notice as the WP minimum requirement is 5.2.4
+			and this notifies about a parameter which was added in 5.2.4. -->
+		<exclude name="PHPCompatibility.PHP.NewFunctionParameters.debug_backtrace_optionsFound"/>
+	</rule>
+
+	<!--
+		##### WordPress sniffs #####
+		The `WordPress-Extra` ruleset contains the WP Core rules + best practices.
+		Other rulesets which could be included in the future:
+		WordPress-VIP
+		WordPress-Docs
+	-->
+	<rule ref="WordPress-Extra">
+		<!-- No need to lint the PHP, this is done in a separate task in the travis script. -->
+		<exclude name="Generic.PHP.Syntax"/>
+
+		<!-- Bit over-zealous, we're not using the value, just checking whether it's set.
+			 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/737 -->
+		<exclude name="WordPress.CSRF.NonceVerification"/>
+	</rule>
+
+	<!-- Downgrade the XSS sniff to a warning. These issues *do* need to be addressed at some point,
+		 but shouldn't fail the build at this moment. -->
+	<rule ref="WordPress.XSS.EscapeOutput.OutputNotEscaped">
+		<type>warning</type>
+	</rule>
+
+	<!-- Ignore error about the use of debug functions. This is a debug plugin after all. -->
+	<rule ref="WordPress.PHP.DevelopmentFunctions">
+		<properties>
+			<property name="exclude" value="error_log" />
+		</properties>
+	</rule>
+
+	<!-- Enable verification that all I18n calls use the correct text-domain. -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="debug-bar"/>
+		</properties>
+	</rule>
+
+	<!-- Enable verification that everything in the global namespace is prefixed. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" value="debug_bar" />
+		</properties>
+	</rule>
+
+	<!-- Set the minimum supported version for this plugin. -->
+	<rule ref="WordPress.WP.DeprecatedFunctions">
+		<properties>
+			<property name="minimum_supported_version" value="3.4" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.WP.DeprecatedClasses">
+		<properties>
+			<property name="minimum_supported_version" value="3.4" />
+		</properties>
+	</rule>
+
+	<!-- To be activated once PR #826 in WPCS has been merged.
+	<rule ref="WordPress.WP.DeprecatedParameter">
+		<properties>
+			<property name="minimum_supported_version" value="3.4" />
+		</properties>
+	</rule>
+	-->
+
+	<!-- Allow the main file to not comply with the codestyle rules.
+		 Changing the filename now, would break recognition of the plugin as active on upgrade. -->
+	<rule ref="WordPress.Files.FileName">
+		<exclude-pattern>*/debug-bar.php</exclude-pattern>
+	</rule>
+
+</ruleset>


### PR DESCRIPTION
* Lint the PHP files against parse errors on all supported PHP versions.
* Check PHP codestyle using the WordPress Coding Standards `WordPress-Extra` ruleset (= Core + best practices)
* Check the JS files for parse errors.
* Check the JS codestyle using the `wordpress` preset ruleset.

To be merged **after** #28 as only then the build will pass.

@dd32 If you have a chance, would you mind turned travis on for this repo ?

/cc @obenland 