### PR TITLE
Don't prevent error logging when silencing error notices for deprecated WP functionality

### DIFF
--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -74,6 +74,8 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 
 		$key = md5( $location . ':' . $message );
 		$this->deprecated_functions[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, $bt ) );
+
+		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . '  in ' . $location );
 	}
 
 	function deprecated_file_included( $old_file, $replacement, $version, $message ) {
@@ -93,6 +95,8 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 
 		$key = md5( $location . ':' . $message );
 		$this->deprecated_files[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, 4 ) );
+
+		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . '  in ' . $location );
 	}
 
 	function deprecated_argument_run( $function, $message, $version ) {
@@ -120,5 +124,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		}
 
 		$this->deprecated_arguments[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, $bt ) );
+
+		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . '  in ' . $location );
 	}
 }


### PR DESCRIPTION
Any existing error log directives should be respected.

By silencing the error notices as is done in [line 19](https://github.com/dd32/debug-bar/blob/master/panels/class-debug-bar-deprecated.php#L19), `trigger_error()` was completely bypassed which meant that errors did not show on screen nor in the logs and as the admin bar highlight isn't working nearly as well as it should (fix upcoming in a separate PR), this meant that people were missing errors.

By adding an `error_log()` call with at least some relevant information, those devs relying on error logs will not miss the notices.

In case no error logging is enabled on the server, the `error_log()` call will do nothing.

Extracted from #17 as it addresses a stand-alone issue.

**Note**: this PR will conflict with #33. I will rebase PRs after each one of these PRs has been merged to fix the conflicts.