### PR TITLE
:rocket: Fix the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@
 # Use new container based environment
 sudo: false
 
+dist: trusty
+
 # Declare project language.
 # @link http://about.travis-ci.org/docs/user/languages/php/
 language: php
@@ -15,8 +17,10 @@ matrix:
   include:
     # aliased to 5.2.17
     - php: '5.2'
+      dist: precise
     # aliased to 5.3.29
     - php: '5.3'
+      dist: precise
     # aliased to a recent 5.4.x version
     - php: '5.4'
     # aliased to a recent 5.5.x version
@@ -36,17 +40,17 @@ matrix:
 
 before_script:
     - export PHPCS_DIR=/tmp/phpcs
-    - export SNIFFS_DIR=/tmp/sniffs
+    - export WPCS_DIR=/tmp/wpcs
+    - export PHPCOMPAT_DIR=/tmp/phpcompatibility
     # Install CodeSniffer for WordPress Coding Standards checks.
     - if [[ "$SNIFF" == "1" ]]; then git clone -b 2.9 --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
     # Install WordPress Coding Standards.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b develop --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b develop --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
     # Install PHP Compatibility sniffs.
-    # @TODO ADJUST PATH FOR Composer PR when merged!
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR; fi
     # Set install path for PHPCS sniffs.
     # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR; fi
     # After CodeSniffer install you should refresh your path.
     - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
     # Install JSCS: JavaScript Code Style checker.
@@ -74,4 +78,4 @@ script:
     # Uses a custom ruleset based on WordPress. This ruleset is automatically
     # picked up by PHPCS as it's named `phpcs.xml(.dist)`.
     # Only fails the build on errors, not warnings, but still show warnings in the output.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --runtime-set ignore_warnings_on_exit 1; fi
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --report-summary --report-source --report-full --runtime-set ignore_warnings_on_exit 1; fi

--- a/debug-bar.php
+++ b/debug-bar.php
@@ -140,7 +140,7 @@ class Debug_Bar {
 		);
 
 		foreach ( $classes as $class ) {
-			$this->panels[] = new $class;
+			$this->panels[] = new $class();
 		}
 
 		$this->panels = apply_filters( 'debug_bar_panels', $this->panels );


### PR DESCRIPTION
* Adjust the way the PHPCompatibility PHPCS standard is installed. See: https://github.com/wimg/PHPCompatibility/pull/446
* Anticipate the Travis change over to using `trusty` containers which would start breaking the builds for PHP 5.2 and 5.3 soon enough. See: https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
* Fix one object instantiation without parenthesis - new sniff which was added to WPCS: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1033
* Show summary and source reports at the top of the PHPCS output to be able to quickly identify the error files and error types.