### PR TITLE
Fix warning when php_uname() is disabled.

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -238,9 +238,16 @@ class Debug_Bar {
 					<?php
 					//@todo: Add a links to information about WP_DEBUG, PHP version, MySQL version, and Peak Memory.
 					$statuses   = array();
+
+					$host_name = __( 'Site', 'debug-bar' );
+					if ( function_exists( 'php_uname' ) ) {
+						$host_name = php_uname( 'n' );
+					} elseif ( ! empty( $_SERVER['SERVER_NAME'] ) ) {
+						$host_name = $_SERVER['SERVER_NAME'];
+					}
 					$statuses[] = array(
 						'site',
-						php_uname( 'n' ),
+						$host_name,
 						/* translators: %d is the site id number in a multi-site setting. */
 						sprintf( __( '#%d', 'debug-bar' ), get_current_blog_id() ),
 					);


### PR DESCRIPTION
PHP provides an ini_directive through which hosts can disable functions for security reasons.
`disable_functions = php_uname`
Recently a user reported the `php_uname()` function to be disabled causing a warning to that effect.

I've reproduced the issue. See the below screenshot.

This "fix" is a work-around. If `php_uname` is enabled, it will use the host name as provided through that function, otherwise it will check the `$_SERVER['SERVER_NAME']` value and if all else fails, it will just display the text string 'Site'.

Fixes https://wordpress.org/support/topic/php_uname-has-been-disabled-for-security-reasons-2/

The fix can be tested by setting the above mentioned ini directive for your local PHP install & restarting the server.

![screenshot](https://snag.gy/y5PX0o.jpg)