### PR TITLE
Remove `rel` attribute for admin bar menu links.

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -185,9 +185,6 @@ class Debug_Bar {
 				'id'     => "debug-bar-$panel_class",
 				'title'  => $panel->title(),
 				'href'   => '#debug-menu-target-' . esc_attr( $panel_class ),
-				'meta'   => array(
-					'rel' => '#debug-menu-link-' . esc_attr( $panel_class ),
-				),
 			) );
 		}
 	}


### PR DESCRIPTION
The `add_menu()` call currently generates HTML admin bar menu items like so:
```html
<li id="wp-admin-bar-debug-bar-Debug_Bar_Queries"><a class="ab-item" href="#debug-menu-target-Debug_Bar_Queries" rel="#debug-menu-link-Debug_Bar_Queries">Queries</a>		</li>
```

The `rel` attribute generates a HTML Error: `Bad value “#debug-menu-link-Debug_Bar_Queries” for attribute “rel” on element “a”: The string “#debug-menu-link-Debug_Bar_Queries” is not a registered keyword.`

Unless someone can explain to me what the added value is of having a `rel` which will generate HTML errors, I think this ought to be removed.

Refs:
* https://html.spec.whatwg.org/multipage/links.html#linkTypes
* https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types