### PR TITLE
Add visibility modifiers to all methods and properties

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -37,7 +37,7 @@ class Debug_Bar {
 
 	public $panels = array();
 
-	function __construct() {
+	public function __construct() {
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			add_action( 'admin_init', array( $this, 'init_ajax' ) );
 		}
@@ -50,14 +50,14 @@ class Debug_Bar {
 		Debug_Bar_Deprecated::start_logging();
 	}
 
-	function Debug_Bar() {
+	public function Debug_Bar() {
 		if ( function_exists( '_deprecated_constructor' ) ) {
 			_deprecated_constructor( __METHOD__, '0.8.3', __CLASS__ );
 		}
 		self::__construct();
 	}
 
-	function init() {
+	public function init() {
 		if ( ! $this->enable_debug_bar() ) {
 			Debug_Bar_PHP::stop_logging();
 			Debug_Bar_Deprecated::stop_logging();
@@ -86,7 +86,7 @@ class Debug_Bar {
 	 *
 	 * @return bool
 	 */
-	function is_wp_login() {
+	public function is_wp_login() {
 		return 'wp-login.php' === basename( $_SERVER['SCRIPT_NAME'] );
 	}
 
@@ -98,7 +98,7 @@ class Debug_Bar {
 	 * @param bool $ajax Whether this is an ajax call or not. Defaults to false.
 	 * @return bool
 	 */
-	function enable_debug_bar( $ajax = false ) {
+	protected function enable_debug_bar( $ajax = false ) {
 		$enable = false;
 
 		if ( $ajax && is_super_admin() ) {
@@ -117,7 +117,7 @@ class Debug_Bar {
 		return apply_filters( 'debug_bar_enable', $enable );
 	}
 
-	function init_ajax() {
+	public function init_ajax() {
 		if ( ! $this->enable_debug_bar( true ) ) {
 			Debug_Bar_PHP::stop_logging();
 			Debug_Bar_Deprecated::stop_logging();
@@ -161,7 +161,7 @@ class Debug_Bar {
 		}
 	}
 
-	function enqueue() {
+	protected function enqueue() {
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '.dev' : '';
 
 		wp_enqueue_style( 'debug-bar', plugins_url( "css/debug-bar$suffix.css", __FILE__ ), array(), '20170802' );
@@ -171,7 +171,7 @@ class Debug_Bar {
 		do_action( 'debug_bar_enqueue_scripts' );
 	}
 
-	function init_panels() {
+	protected function init_panels() {
 		$classes = array(
 			'Debug_Bar_PHP',
 			'Debug_Bar_Queries',
@@ -189,7 +189,7 @@ class Debug_Bar {
 		$this->panels = apply_filters( 'debug_bar_panels', $this->panels );
 	}
 
-	function ensure_ajaxurl() {
+	public function ensure_ajaxurl() {
 		?>
 		<script type="text/javascript">
 			//<![CDATA[
@@ -199,7 +199,7 @@ class Debug_Bar {
 		<?php
 	}
 
-	function admin_bar_menu() {
+	public function admin_bar_menu() {
 		global $wp_admin_bar;
 
 		$classes = apply_filters( 'debug_bar_classes', array() );
@@ -235,7 +235,7 @@ class Debug_Bar {
 		}
 	}
 
-	function body_class( $classes ) {
+	public function body_class( $classes ) {
 		if ( is_array( $classes ) ) {
 			$classes[] = 'debug-bar-maximized';
 		} else {
@@ -253,7 +253,7 @@ class Debug_Bar {
 		return $classes;
 	}
 
-	function render() {
+	public function render() {
 		global $wpdb;
 
 		if ( empty( $this->panels ) ) {

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -66,11 +66,11 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		}
 	}
 
-	function init() {
+	protected function init() {
 		$this->title( __( 'Deprecated', 'debug-bar' ) );
 	}
 
-	function prerender() {
+	public function prerender() {
 		$this->set_visible(
 			count( self::$deprecated_functions )
 			|| count( self::$deprecated_files )
@@ -78,7 +78,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		);
 	}
 
-	function render() {
+	public function render() {
 		echo '<div id="debug-bar-deprecated">';
 
 		$this->render_panel_info_block( __( 'Total Functions:', 'debug-bar' ), count( self::$deprecated_functions ) );

--- a/panels/class-debug-bar-js.php
+++ b/panels/class-debug-bar-js.php
@@ -3,7 +3,7 @@
 class Debug_Bar_JS extends Debug_Bar_Panel {
 	public $real_error_handler = array();
 
-	function init() {
+	protected function init() {
 		$this->title( __( 'JavaScript', 'debug-bar' ) );
 
 		/*
@@ -14,7 +14,7 @@ class Debug_Bar_JS extends Debug_Bar_Panel {
 		wp_enqueue_script( 'debug-bar-js', plugins_url( "js/debug-bar-js$suffix.js", dirname( __FILE__ ) ), array( 'jquery' ), '20170623' );
 	}
 
-	function render() {
+	public function render() {
 		echo '<div id="debug-bar-js">';
 		$this->render_panel_info_block( __( 'Total Errors:', 'debug-bar' ), '<span id="debug-bar-js-error-count">0</span>' );
 		echo '<ol class="debug-bar-js-list" id="debug-bar-js-errors"></ol>' . "\n";

--- a/panels/class-debug-bar-object-cache.php
+++ b/panels/class-debug-bar-object-cache.php
@@ -1,16 +1,16 @@
 <?php
 
 class Debug_Bar_Object_Cache extends Debug_Bar_Panel {
-	function init() {
+	protected function init() {
 		$this->title( __( 'Object Cache', 'debug-bar' ) );
 	}
 
-	function prerender() {
+	public function prerender() {
 		global $wp_object_cache;
 		$this->set_visible( is_object( $wp_object_cache ) && method_exists( $wp_object_cache, 'stats' ) );
 	}
 
-	function render() {
+	public function render() {
 		global $wp_object_cache;
 
 		$this->render_panel_info_block( __( 'Cache Hits:', 'debug-bar' ), $wp_object_cache->cache_hits );

--- a/panels/class-debug-bar-panel.php
+++ b/panels/class-debug-bar-panel.php
@@ -4,7 +4,7 @@ class Debug_Bar_Panel {
 	public $_title = '';
 	public $_visible = true;
 
-	function __construct( $title = '' ) {
+	public function __construct( $title = '' ) {
 		$this->title( $title );
 
 		if ( $this->init() === false ) {
@@ -16,7 +16,7 @@ class Debug_Bar_Panel {
 		add_filter( 'debug_bar_classes', array( $this, 'debug_bar_classes' ) );
 	}
 
-	function Debug_Bar_Panel( $title = '' ) {
+	public function Debug_Bar_Panel( $title = '' ) {
 		if ( function_exists( '_deprecated_constructor' ) ) {
 			_deprecated_constructor( __METHOD__, '0.8.3', __CLASS__ );
 		}
@@ -26,20 +26,20 @@ class Debug_Bar_Panel {
 	/**
 	 * Initializes the panel.
 	 */
-	function init() {}
+	protected function init() {}
 
-	function prerender() {}
+	public function prerender() {}
 
 	/**
 	 * Renders the panel.
 	 */
-	function render() {}
+	public function render() {}
 
-	function is_visible() {
+	public function is_visible() {
 		return $this->_visible;
 	}
 
-	function set_visible( $visible ) {
+	protected function set_visible( $visible ) {
 		$this->_visible = $visible;
 	}
 
@@ -49,7 +49,7 @@ class Debug_Bar_Panel {
 	 * @param null $title
 	 * @return string|void
 	 */
-	function title( $title = null ) {
+	public function title( $title = null ) {
 		if ( ! isset( $title ) ) {
 			return $this->_title;
 		}
@@ -57,7 +57,7 @@ class Debug_Bar_Panel {
 		$this->_title = $title;
 	}
 
-	function debug_bar_classes( $classes ) {
+	public function debug_bar_classes( $classes ) {
 		return $classes;
 	}
 

--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -54,7 +54,7 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 		restore_error_handler();
 	}
 
-	function init() {
+	protected function init() {
 		if ( ! WP_DEBUG ) {
 			return false;
 		}
@@ -62,11 +62,11 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 		$this->title( __( 'Notices / Warnings', 'debug-bar' ) );
 	}
 
-	function is_visible() {
+	public function is_visible() {
 		return count( self::$notices ) || count( self::$warnings );
 	}
 
-	function debug_bar_classes( $classes ) {
+	public function debug_bar_classes( $classes ) {
 		if ( count( self::$warnings ) ) {
 			$classes[] = 'debug-bar-php-warning-summary';
 		} elseif ( count( self::$notices ) ) {
@@ -139,7 +139,7 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 		}
 	}
 
-	function render() {
+	public function render() {
 		echo '<div id="debug-bar-php">';
 
 		$this->render_panel_info_block( __( 'Total Warnings:', 'debug-bar' ), count( self::$warnings ) );

--- a/panels/class-debug-bar-queries.php
+++ b/panels/class-debug-bar-queries.php
@@ -2,15 +2,15 @@
 
 class Debug_Bar_Queries extends Debug_Bar_Panel {
 
-	function init() {
+	protected function init() {
 		$this->title( __( 'Queries', 'debug-bar' ) );
 	}
 
-	function prerender() {
+	public function prerender() {
 		$this->set_visible( defined( 'SAVEQUERIES' ) && SAVEQUERIES || ! empty( $GLOBALS['EZSQL_ERROR'] ) );
 	}
 
-	function debug_bar_classes( $classes ) {
+	public function debug_bar_classes( $classes ) {
 		if ( ! empty( $GLOBALS['EZSQL_ERROR'] ) ) {
 			$classes[] = 'debug-bar-php-warning-summary';
 		}
@@ -18,7 +18,7 @@ class Debug_Bar_Queries extends Debug_Bar_Panel {
 		return $classes;
 	}
 
-	function render() {
+	public function render() {
 		global $wpdb, $EZSQL_ERROR;
 
 		$out        = '';

--- a/panels/class-debug-bar-request.php
+++ b/panels/class-debug-bar-request.php
@@ -1,15 +1,15 @@
 <?php
 
 class Debug_Bar_Request extends Debug_Bar_Panel {
-	function init() {
+	protected function init() {
 		$this->title( __( 'Request', 'debug-bar' ) );
 	}
 
-	function prerender() {
+	public function prerender() {
 		$this->set_visible( ! is_admin() );
 	}
 
-	function render() {
+	public function render() {
 		global $wp;
 
 		echo '<div id="debug-bar-request">';

--- a/panels/class-debug-bar-wp-query.php
+++ b/panels/class-debug-bar-wp-query.php
@@ -1,15 +1,15 @@
 <?php
 
 class Debug_Bar_WP_Query extends Debug_Bar_Panel {
-	function init() {
+	protected function init() {
 		$this->title( __( 'WP Query', 'debug-bar' ) );
 	}
 
-	function prerender() {
+	public function prerender() {
 		$this->set_visible( defined( 'SAVEQUERIES' ) && SAVEQUERIES );
 	}
 
-	function render() {
+	public function render() {
 		global $template, $wp_query;
 
 		$queried_object = get_queried_object();
@@ -94,17 +94,17 @@ class Debug_Bar_WP_Query extends Debug_Bar_Panel {
 		if ( ! is_null( $queried_object ) ) {
 			echo '<h3>', __( 'Queried Object:', 'debug-bar' ), '</h3>';
 			echo '<table class="debug-bar-wp-query-list"><tbody>';
-			$this->_recursive_print_kv( $queried_object );
+			$this->recursive_print_kv( $queried_object );
 			echo '</tbody></table>';
 		}
 		echo '</div>';
 	}
 
-	protected function _recursive_print_kv( $kv_array ) {
+	protected function recursive_print_kv( $kv_array ) {
 		foreach ( $kv_array as $key => $value ) {
 			if ( is_object( $value ) || is_array( $value ) ) {
 				echo '<tr><th>', esc_html( $key ), '</th> <td>&rArr;</td> <td>';
-				$this->_recursive_print_kv( $value );
+				$this->recursive_print_kv( $value );
 				echo '</td></tr>';
 			} else {
 				echo '<tr><th>', esc_html( $key ), '</th> <td>&rArr;</td> <td>', esc_html( $value ), '</td></tr>';


### PR DESCRIPTION
Some new checks have been added to WPCS to verify that visibility modifiers are always used which will cause the builds for this plugin to break with the current codebase.

Well, we know those had to be added to this plugin anyhow, so now is as good a time as any to do this.

As a general rule of thumb I've made everything `protected`, except:
* Class constructors - these need to be `public` for how the classes are instantiated in this plugin.
* The error handler being registered with PHP - this has to be a `public` method.
* Methods which are being called via hooks, including `Debug_Bar_Panel::debug_bar_classes()` - these need to be `public`.
* Methods which are being called from the main `Debug_Bar` class - i.e. `Debug_Bar_Panel::is_visible()`, `Debug_Bar_Panel::title()`, `Debug_Bar_Panel::prerender()` and `Debug_Bar_Panel::render()` - these need to be `public`.

Using `protected` whenever possible creates the right balance as:
* Add-ons will need to overload certain methods from the `Debug_Bar_Panel` class, which means that using `private` is not an option for most methods.
* Also, using `protected` will not break compatibility for add-on plugins which already have a visibility defined as overloaded methods can be "more" visible, not less.

I've also renamed one method which was indicated in the PHP 4 manner to be private with an underscore prefix.