### PR TITLE
Remove an unused property

### DIFF
--- a/panels/class-debug-bar-js.php
+++ b/panels/class-debug-bar-js.php
@@ -1,7 +1,6 @@
 <?php
 
 class Debug_Bar_JS extends Debug_Bar_Panel {
-	public $real_error_handler = array();
 
 	function init() {
 		$this->title( __( 'JavaScript', 'debug-bar' ) );


### PR DESCRIPTION
This property is used in the `Debug_Bar_PHP` panel, but not in the `Debug_Bar_JS` panel. Possibly a copy/paste artefact from when the panel was created.

P.S.: the build won't pass until PR #41 is merged.