### PR TITLE
README: Add "Requires PHP" header

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@ Tags: debug
 Tested up to: 4.8
 Stable tag: 0.9
 Requires at least: 3.4
+Requires PHP: 5.2.4
 
 Adds a debug menu to the admin bar that shows query, cache, and other helpful debugging information.
 


### PR DESCRIPTION
This new header has been soft launched on August 25th 2017.

Refs:
* https://meta.trac.wordpress.org/ticket/2952
* https://meta.trac.wordpress.org/changeset/5841