### PR TITLE
Debug_Bar_Panel: turn it into an abstract class

### DIFF
--- a/panels/class-debug-bar-panel.php
+++ b/panels/class-debug-bar-panel.php
@@ -1,6 +1,6 @@
 <?php
 
-class Debug_Bar_Panel {
+abstract class Debug_Bar_Panel {
 	public $_title = '';
 	public $_visible = true;
 
@@ -26,14 +26,14 @@ class Debug_Bar_Panel {
 	/**
 	 * Initializes the panel.
 	 */
-	protected function init() {}
+	abstract protected function init();
 
 	public function prerender() {}
 
 	/**
 	 * Renders the panel.
 	 */
-	public function render() {}
+	abstract public function render();
 
 	public function is_visible() {
 		return $this->_visible;


### PR DESCRIPTION
The class is already used as if it were an abstract class, just not annotated as such. Now it is.

Any methods which are compulsory for panels to implement have been made `abstract` as well.
Methods which are optional for panels to implement have been left alone.