### PR TITLE
Add support for deprecated hooks & constructors.

### DIFF
--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -35,6 +35,15 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 	public static $deprecated_arguments = array();
 
 	/**
+	 * Storage to log notices about deprecated class constructors being called.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @var array
+	 */
+	public static $deprecated_constructors = array();
+
+	/**
 	 * Start logging deprecation notices thrown by WP.
 	 *
 	 * @since 0.10.0
@@ -43,9 +52,10 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		add_action( 'deprecated_function_run', array( __CLASS__, 'deprecated_function_run' ), 10, 3 );
 		add_action( 'deprecated_file_included', array( __CLASS__, 'deprecated_file_included' ), 10, 4 );
 		add_action( 'deprecated_argument_run',  array( __CLASS__, 'deprecated_argument_run' ),  10, 3 );
+		add_action( 'deprecated_constructor_run',  array( __CLASS__, 'deprecated_constructor_run' ),  10, 3 );
 
 		// Silence E_NOTICE for deprecated usage.
-		foreach ( array( 'function', 'file', 'argument' ) as $item ) {
+		foreach ( array( 'function', 'file', 'argument', 'constructor' ) as $item ) {
 			add_filter( "deprecated_{$item}_trigger_error", '__return_false' );
 		}
 	}
@@ -59,9 +69,10 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		remove_action( 'deprecated_function_run', array( __CLASS__, 'deprecated_function_run' ), 10 );
 		remove_action( 'deprecated_file_included', array( __CLASS__, 'deprecated_file_included' ), 10 );
 		remove_action( 'deprecated_argument_run',  array( __CLASS__, 'deprecated_argument_run' ),  10 );
+		remove_action( 'deprecated_constructor_run',  array( __CLASS__, 'deprecated_constructor_run' ),  10 );
 
 		// Don't silence E_NOTICE for deprecated usage.
-		foreach ( array( 'function', 'file', 'argument' ) as $item ) {
+		foreach ( array( 'function', 'file', 'argument', 'constructor' ) as $item ) {
 			remove_filter( "deprecated_{$item}_trigger_error", '__return_false' );
 		}
 	}
@@ -75,6 +86,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			count( self::$deprecated_functions )
 			|| count( self::$deprecated_files )
 			|| count( self::$deprecated_arguments )
+			|| count( self::$deprecated_constructors )
 		);
 	}
 
@@ -84,6 +96,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		$this->render_panel_info_block( __( 'Total Functions:', 'debug-bar' ), count( self::$deprecated_functions ) );
 		$this->render_panel_info_block( __( 'Total Arguments:', 'debug-bar' ), count( self::$deprecated_arguments ) );
 		$this->render_panel_info_block( __( 'Total Files:', 'debug-bar' ), count( self::$deprecated_files ) );
+		$this->render_panel_info_block( __( 'Total Constructors:', 'debug-bar' ), count( self::$deprecated_constructors ) );
 
 		$this->render_error_list(
 			self::$deprecated_functions,
@@ -99,6 +112,11 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			self::$deprecated_files,
 			__( 'DEPRECATED FILE:', 'debug-bar' ),
 			'deprecated-file'
+		);
+		$this->render_error_list(
+			self::$deprecated_constructors,
+			__( 'DEPRECATED CONSTRUCTOR:', 'debug-bar' ),
+			'deprecated-constructor'
 		);
 
 		echo '</div>';
@@ -208,5 +226,50 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		self::$deprecated_arguments[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, $bt ) );
 
 		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . '  in ' . $location );
+	}
+
+	/**
+	 * Log notices about deprecated (PHP 4) class constructors being run.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @param string $class        The class containing the deprecated constructor.
+	 * @param string $version      The version of WordPress that deprecated the function.
+	 * @param string $parent_class Optional. The parent class calling the deprecated constructor.
+	 */
+	public static function deprecated_constructor_run( $class, $version, $parent_class = '' ) {
+		$backtrace = debug_backtrace( false );
+		$bt        = 4;
+		if ( ! isset( $backtrace[4]['file'] ) && 'call_user_func_array' === $backtrace[5]['function'] ) {
+			$bt = 6;
+		}
+
+		$file     = ( isset( $backtrace[ $bt ]['file'] ) ? $backtrace[ $bt ]['file'] : 0 );
+		$line     = ( isset( $backtrace[ $bt ]['line'] ) ? $backtrace[ $bt ]['line'] : 0 );
+		$location = $file . ':' . $line;
+
+		if ( ! empty( $parent_class ) ) {
+			$message = sprintf(
+				/* translators: 1: PHP class name, 2: PHP parent class name, 3: version number, 4: __construct() method */
+				__( 'The called constructor method for %1$s in %2$s is <strong>deprecated</strong> since version %3$s! Use %4$s instead.', 'debug-bar' ),
+				$class,
+				$parent_class,
+				$version,
+				'<code>__construct()</code>'
+			);
+		} else {
+			$message = sprintf(
+				/* translators: 1: PHP class name, 2: version number, 3: __construct() method */
+				__( 'The called constructor method for %1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.', 'debug-bar' ),
+				$class,
+				$version,
+				'<code>__construct()</code>'
+			);
+		}
+
+		$key = md5( $location . ':' . $message );
+		self::$deprecated_constructors[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, $bt ) );
+
+		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . ' in ' . $location );
 	}
 }

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -35,6 +35,15 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 	public static $deprecated_arguments = array();
 
 	/**
+	 * Storage to log notices about deprecated hooks being called.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @var array
+	 */
+	public static $deprecated_hooks = array();
+
+	/**
 	 * Storage to log notices about deprecated class constructors being called.
 	 *
 	 * @since 0.10.0
@@ -52,6 +61,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		add_action( 'deprecated_function_run', array( __CLASS__, 'deprecated_function_run' ), 10, 3 );
 		add_action( 'deprecated_file_included', array( __CLASS__, 'deprecated_file_included' ), 10, 4 );
 		add_action( 'deprecated_argument_run',  array( __CLASS__, 'deprecated_argument_run' ),  10, 3 );
+		add_action( 'deprecated_hook_run',  array( __CLASS__, 'deprecated_hook_run' ),  10, 4 );
 		add_action( 'deprecated_constructor_run',  array( __CLASS__, 'deprecated_constructor_run' ),  10, 3 );
 
 		// Silence E_NOTICE for deprecated usage.
@@ -69,6 +79,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		remove_action( 'deprecated_function_run', array( __CLASS__, 'deprecated_function_run' ), 10 );
 		remove_action( 'deprecated_file_included', array( __CLASS__, 'deprecated_file_included' ), 10 );
 		remove_action( 'deprecated_argument_run',  array( __CLASS__, 'deprecated_argument_run' ),  10 );
+		remove_action( 'deprecated_hook_run',  array( __CLASS__, 'deprecated_hook_run' ),  10 );
 		remove_action( 'deprecated_constructor_run',  array( __CLASS__, 'deprecated_constructor_run' ),  10 );
 
 		// Don't silence E_NOTICE for deprecated usage.
@@ -86,6 +97,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			count( self::$deprecated_functions )
 			|| count( self::$deprecated_files )
 			|| count( self::$deprecated_arguments )
+			|| count( self::$deprecated_hooks )
 			|| count( self::$deprecated_constructors )
 		);
 	}
@@ -96,6 +108,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		$this->render_panel_info_block( __( 'Total Functions:', 'debug-bar' ), count( self::$deprecated_functions ) );
 		$this->render_panel_info_block( __( 'Total Arguments:', 'debug-bar' ), count( self::$deprecated_arguments ) );
 		$this->render_panel_info_block( __( 'Total Files:', 'debug-bar' ), count( self::$deprecated_files ) );
+		$this->render_panel_info_block( __( 'Total Hooks:', 'debug-bar' ), count( self::$deprecated_hooks ) );
 		$this->render_panel_info_block( __( 'Total Constructors:', 'debug-bar' ), count( self::$deprecated_constructors ) );
 
 		$this->render_error_list(
@@ -112,6 +125,11 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			self::$deprecated_files,
 			__( 'DEPRECATED FILE:', 'debug-bar' ),
 			'deprecated-file'
+		);
+		$this->render_error_list(
+			self::$deprecated_hooks,
+			__( 'DEPRECATED HOOK:', 'debug-bar' ),
+			'deprecated-hook'
 		);
 		$this->render_error_list(
 			self::$deprecated_constructors,
@@ -224,6 +242,52 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		}
 
 		self::$deprecated_arguments[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, $bt ) );
+
+		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . '  in ' . $location );
+	}
+
+	/**
+	 * Log notices about deprecated hook being used.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @param string $hook         The hook that was used.
+	 * @param string $version      The version of WordPress that deprecated the hook.
+	 * @param string $replacement  The hook that should have been used.
+	 * @param string $hook_message A message regarding the change.
+	 */
+	public static function deprecated_hook_run( $hook, $version, $replacement, $hook_message ) {
+		$backtrace = debug_backtrace( false );
+		$bt        = 4;
+		// Check if we're a hook callback.
+		if ( ! isset( $backtrace[4]['file'] ) && 'call_user_func_array' === $backtrace[5]['function'] ) {
+			$bt = 6;
+		}
+		$file     = ( isset( $backtrace[ $bt ]['file'] ) ? $backtrace[ $bt ]['file'] : 0 );
+		$line     = ( isset( $backtrace[ $bt ]['line'] ) ? $backtrace[ $bt ]['line'] : 0 );
+		$location = $file . ':' . $line;
+
+		if ( ! is_null( $replacement ) ) {
+			$message = sprintf(
+				/* translators: %1$s is a hook name, %2$s a version number, %3$s an alternative hook to use. */
+				__( '%1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.' , 'debug-bar' ),
+				$hook,
+				$version,
+				$replacement
+			);
+			$message .= ' ' . $hook_message;
+		} else {
+			$message = sprintf(
+				/* translators: %1$s is a hook name, %2$s a version number. */
+				__( '%1$s is <strong>deprecated</strong> since version %2$s with no alternative available.', 'debug-bar' ),
+				$hook,
+				$version
+			);
+			$message .= ' ' . $hook_message;
+		}
+
+		$key = md5( $location . ':' . $message );
+		self::$deprecated_hooks[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, $bt ) );
 
 		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . '  in ' . $location );
 	}


### PR DESCRIPTION
WP 4.3.0 added the `_deprecated_constructor()` function.
WP 4.6.0 added the `_deprecated_hook()` function.

Errors triggered by either of these two were so far not being caught by the Debug Bar.

This PR fixes that.


### Testing the PR

Add the following snippet to the `Debug_Bar_Object_Cache` class:
```php
	function Debug_Bar_Object_Cache() {
		Debug_Bar_Panel::Debug_Bar_Panel();
	}

```

And the following snippet to a child theme or must use plugin:
```php
add_action( 'after_setup_theme', function() {
	add_filter( 'testing-123', '__return_false' );
	apply_filters_deprecated( 'testing-123', array( true ), '1.0' );
} );
```

Without this PR, the `Deprecated` Panel will not show.

With this PR, it looks like:
![screenshot](https://snag.gy/DJGa4V.jpg)