### PR TITLE
Add logging of PHP strict, deprecated and silenced error notices.

### DIFF
--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -13,7 +13,7 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 	public static $warnings = array();
 
 	/**
-	 * Storage to log PHP errors encountered.
+	 * Storage to log PHP notices encountered.
 	 *
 	 * @since 0.5
 	 * @since 0.10.0 Changed to static to allow for error logging to start early.
@@ -21,6 +21,33 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 	 * @var array
 	 */
 	public static $notices = array();
+
+	/**
+	 * Storage to log PHP strict errors encountered.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @var array
+	 */
+	public static $strict = array();
+
+	/**
+	 * Storage to log PHP deprecated errors encountered.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @var array
+	 */
+	public static $deprecated = array();
+
+	/**
+	 * Storage to log silenced PHP errors encountered.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @var array
+	 */
+	public static $silenced = array();
 
 	/**
 	 * Store the callback for the previous error handler.
@@ -63,13 +90,19 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 	}
 
 	public function is_visible() {
-		return count( self::$notices ) || count( self::$warnings );
+		return count( self::$notices )
+			|| count( self::$warnings )
+			|| count( self::$strict )
+			|| count( self::$deprecated )
+			|| count( self::$silenced );
 	}
 
 	public function debug_bar_classes( $classes ) {
 		if ( count( self::$warnings ) ) {
 			$classes[] = 'debug-bar-php-warning-summary';
-		} elseif ( count( self::$notices ) ) {
+		} elseif ( count( self::$notices ) || count( self::$strict )
+			|| count( self::$deprecated ) || count( self::$silenced )
+		) {
 			$classes[] = 'debug-bar-php-notice-summary';
 		}
 
@@ -81,6 +114,7 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 	 *
 	 * @since 0.5
 	 * @since 0.10.0 Changed to static to allow for error logging to start early.
+	 * @since 0.10.0 Now also reports strict, deprecated and silenced errors.
 	 *
 	 * @param int    $type    The level of the error raised.
 	 * @param string $message The error message.
@@ -90,46 +124,56 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 	 * @return false To allow for the normal error handler to continue.
 	 */
 	public static function error_handler( $type, $message, $file, $line ) {
-		if ( ! ( error_reporting() & $type ) ) {
-			return false;
-		}
+		$location = $file . ':' . $line;
+		$_key     = md5( $location . ':' . $message );
 
-		$_key = md5( $file . ':' . $line . ':' . $message );
+		if ( 0 === error_reporting() ) {
+			self::$silenced[ $_key ] = array( $location, $message, wp_debug_backtrace_summary( __CLASS__ ) );
+		} else {
 
-		if ( ! defined( 'E_DEPRECATED' ) ) {
-			define( 'E_DEPRECATED', 8192 );
-		}
-		if ( ! defined( 'E_USER_DEPRECATED' ) ) {
-			define( 'E_USER_DEPRECATED', 16384 );
-		}
+			if ( ! defined( 'E_DEPRECATED' ) ) {
+				define( 'E_DEPRECATED', 8192 );
+			}
+			if ( ! defined( 'E_USER_DEPRECATED' ) ) {
+				define( 'E_USER_DEPRECATED', 16384 );
+			}
 
-		switch ( $type ) {
-			case E_WARNING:
-			case E_USER_WARNING:
-				self::$warnings[ $_key ] = array(
-					$file . ':' . $line,
-					$message,
-					wp_debug_backtrace_summary( __CLASS__ ),
-				);
-				break;
-			case E_NOTICE:
-			case E_USER_NOTICE:
-				self::$notices[ $_key ] = array(
-					$file . ':' . $line,
-					$message,
-					wp_debug_backtrace_summary( __CLASS__ ),
-				);
-				break;
-			case E_STRICT:
-				// TODO
-				break;
-			case E_DEPRECATED:
-			case E_USER_DEPRECATED:
-				// TODO
-				break;
-			case 0:
-				// TODO
-				break;
+			switch ( $type ) {
+				case E_WARNING:
+				case E_USER_WARNING:
+					self::$warnings[ $_key ] = array(
+						$location,
+						$message,
+						wp_debug_backtrace_summary( __CLASS__ ),
+					);
+					break;
+
+				case E_NOTICE:
+				case E_USER_NOTICE:
+					self::$notices[ $_key ] = array(
+						$location,
+						$message,
+						wp_debug_backtrace_summary( __CLASS__ ),
+					);
+					break;
+
+				case E_STRICT:
+					self::$strict[ $_key ] = array(
+						$location,
+						$message,
+						wp_debug_backtrace_summary( __CLASS__ ),
+					);
+					break;
+
+				case E_DEPRECATED:
+				case E_USER_DEPRECATED:
+					self::$deprecated[ $_key ] = array(
+						$location,
+						$message,
+						wp_debug_backtrace_summary( __CLASS__ ),
+					);
+					break;
+			}
 		}
 
 		if ( isset( self::$real_error_handler ) ) {
@@ -144,9 +188,15 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 
 		$this->render_panel_info_block( __( 'Total Warnings:', 'debug-bar' ), count( self::$warnings ) );
 		$this->render_panel_info_block( __( 'Total Notices:', 'debug-bar' ), count( self::$notices ) );
+		$this->render_panel_info_block( __( 'Total Strict Notices:', 'debug-bar' ), count( self::$strict ) );
+		$this->render_panel_info_block( __( 'Total Deprecated:', 'debug-bar' ), count( self::$deprecated ) );
+		$this->render_panel_info_block( __( 'Total Silenced:', 'debug-bar' ), count( self::$silenced ) );
 
 		$this->render_error_list( self::$warnings, __( 'WARNING:', 'debug-bar' ), 'php-warning' );
 		$this->render_error_list( self::$notices, __( 'NOTICE:', 'debug-bar' ), 'php-notice' );
+		$this->render_error_list( self::$strict, __( 'STRICT:', 'debug-bar' ), 'php-notice' );
+		$this->render_error_list( self::$deprecated, __( 'DEPRECATED:', 'debug-bar' ), 'php-notice' );
+		$this->render_error_list( self::$silenced, __( 'SILENCED:', 'debug-bar' ), 'php-warning' );
 
 		echo '</div>';
 	}


### PR DESCRIPTION
This was annotated inline as a to do and so far these errors were not displayed in the Debug Bar.

This PR fixes that.


### Testing the PR

Add the following snippet to a child theme or must use plugin:
```php
// Test silenced error
add_action( 'wp', function() {
	@fopen( __DIR__ . '/nonexistant.txt', 'r' );
} );


// Test Deprecated PHP error
class JRF_abc{
   function func( $argument )  {
       $argument = 'It works';
   }
}

add_action( 'wp', function() {
	$obj = new JRF_abc;
	$argument_to_be_changed = 'No it doesn\'t work';
	call_user_method( 'func', $obj, $argument_to_be_changed );
} );


// Test E_STRICT error
class JRF_Strict {
    public function test() {
        return "Test";
    }
}

add_action( 'wp', function() {
	JRF_Strict::test();
} );
```

Load a front-end page to see the effect.
Without this PR, none of the expected errors will not show.

With this PR, it looks like:
![screenshot](https://snag.gy/ezhwtS.jpg)