### PR TITLE
Report on all PHP errors

### DIFF
--- a/panels/class-debug-bar-php.php
+++ b/panels/class-debug-bar-php.php
@@ -42,6 +42,7 @@ class Debug_Bar_PHP extends Debug_Bar_Panel {
 			return false;
 		}
 
+		error_reporting( -1 );
 		self::$real_error_handler = set_error_handler( array( __CLASS__, 'error_handler' ) );
 	}
 


### PR DESCRIPTION
The WP Core `wp_debug_mode()` function sets error_reporting to `E_ALL`. Depending on the PHP version, this _may_ not actually catch **all** errors.
See: https://core.trac.wordpress.org/browser/trunk/src/wp-includes/load.php#L321

Setting the error_reporting to `-1` will **always** report on all errors, independently of PHP version.

Refs:
* http://php.net/manual/en/function.error-reporting.php#refsect1-function.error-reporting-changelog
* http://php.net/manual/en/function.error-reporting.php#refsect1-function.error-reporting-examples
* http://php.net/manual/en/function.error-reporting.php#refsect1-function.error-reporting-notes