### PR TITLE
Travis: run the build tests against PHP 7.2 as well.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
     - php: '7.0'
     # aliased to a recent 7.1.x version
     - php: '7.1'
+    # aliased to a recent 7.2.x version
+    - php: '7.2'
     # bleeding edge PHP
     - php: 'nightly'
 


### PR DESCRIPTION
The new Trusty images as per Sept 7 include an image for PHP 7.2 (even though it hasn't been released yet) and `nightly` is now PHP 7.3-dev.