### PR TITLE
Revert #34

### DIFF
--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -171,8 +171,6 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 
 		$key = md5( $location . ':' . $message );
 		self::$deprecated_functions[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, $bt ) );
-
-		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . '  in ' . $location );
 	}
 
 	/**
@@ -203,8 +201,6 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 
 		$key = md5( $location . ':' . $message );
 		self::$deprecated_files[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, 4 ) );
-
-		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . '  in ' . $location );
 	}
 
 	/**
@@ -242,8 +238,6 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		}
 
 		self::$deprecated_arguments[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, $bt ) );
-
-		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . '  in ' . $location );
 	}
 
 	/**
@@ -288,8 +282,6 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 
 		$key = md5( $location . ':' . $message );
 		self::$deprecated_hooks[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, $bt ) );
-
-		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . '  in ' . $location );
 	}
 
 	/**
@@ -333,7 +325,5 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 
 		$key = md5( $location . ':' . $message );
 		self::$deprecated_constructors[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, $bt ) );
-
-		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . ' in ' . $location );
 	}
 }

--- a/panels/class-debug-bar-doing-it-wrong.php
+++ b/panels/class-debug-bar-doing-it-wrong.php
@@ -120,7 +120,5 @@ class Debug_Bar_Doing_It_Wrong extends Debug_Bar_Panel {
 
 		$key = md5( $location . ':' . $message );
 		self::$doing_it_wrong[ $key ] = array( $location, $notice, wp_debug_backtrace_summary( null, $bt ) );
-
-		error_log( 'Doing it wrong Notice: ' . strip_tags( $notice ) . '  in ' . $location );
 	}
 }


### PR DESCRIPTION
In legacy WordPress installation with a decent amount of outdated code,
looking deprecated and doing_it_wrong notices drowns out real errors
and has the potential to make error logs unusable. This comes with the
potential of additional unforeseeable consequences when using automated
logs and reporting tools.

We can't reasonably expect that all environments that this plugin is being used in are in as pristine of a condition as our local development environments. If developers do want to log these things, they can still add their own callbacks to log these errors.