### PR TITLE
CS: various whitespace fixes to comply with the latest WPCS

### DIFF
--- a/debug-bar.php
+++ b/debug-bar.php
@@ -1,12 +1,19 @@
 <?php
-/*
- Plugin Name: Debug Bar
- Plugin URI: https://wordpress.org/plugins/debug-bar/
- Description: Adds a debug menu to the admin bar that shows query, cache, and other helpful debugging information.
- Author: wordpressdotorg
- Version: 0.9.1-alpha
- Author URI: https://wordpress.org/
- Text Domain: debug-bar
+/**
+ * Debug Bar, a WordPress plugin.
+ *
+ * @package     WordPress\Plugins\Debug Bar
+ * @link        https://wordpress.org/plugins/debug-bar/
+ * @license     http://creativecommons.org/licenses/GPL/2.0/ GNU General Public License, version 2 or higher
+ *
+ * @wordpress-plugin
+ * Plugin Name: Debug Bar
+ * Plugin URI:  https://wordpress.org/plugins/debug-bar/
+ * Description: Adds a debug menu to the admin bar that shows query, cache, and other helpful debugging information.
+ * Author: wordpressdotorg
+ * Version:     0.10.0-alpha
+ * Author URI:  https://wordpress.org/
+ * Text Domain: debug-bar
  */
 
 /***
@@ -66,11 +73,11 @@ class Debug_Bar {
 
 		load_plugin_textdomain( 'debug-bar' );
 
-		add_action( 'admin_bar_menu',   array( $this, 'admin_bar_menu' ), 1000 );
-		add_action( 'admin_footer',     array( $this, 'render' ), 1000 );
-		add_action( 'wp_footer',        array( $this, 'render' ), 1000 );
-		add_action( 'wp_head',          array( $this, 'ensure_ajaxurl' ), 1 );
-		add_filter( 'body_class',       array( $this, 'body_class' ) );
+		add_action( 'admin_bar_menu', array( $this, 'admin_bar_menu' ), 1000 );
+		add_action( 'admin_footer', array( $this, 'render' ), 1000 );
+		add_action( 'wp_footer', array( $this, 'render' ), 1000 );
+		add_action( 'wp_head', array( $this, 'ensure_ajaxurl' ), 1 );
+		add_filter( 'body_class', array( $this, 'body_class' ) );
 		add_filter( 'admin_body_class', array( $this, 'body_class' ) );
 
 		$this->requirements();
@@ -291,7 +298,7 @@ class Debug_Bar {
 				<div id="debug-status">
 					<?php
 					//@todo: Add a links to information about WP_DEBUG, PHP version, MySQL version, and Peak Memory.
-					$statuses   = array();
+					$statuses = array();
 
 					$host_name = __( 'Site', 'debug-bar' );
 					if ( function_exists( 'php_uname' ) ) {

--- a/debug-bar.php
+++ b/debug-bar.php
@@ -301,7 +301,8 @@ class Debug_Bar {
 					$statuses = array();
 
 					$host_name = __( 'Site', 'debug-bar' );
-					if ( function_exists( 'php_uname' ) ) {
+					if ( function_exists( 'php_uname' ) && version_compare( php_version(), '7.0.0', '>' ) === true ) {
+						// phpcs:ignore PHPCompatibility.PHP.NewFunctionParameters.php_uname_modeFound
 						$host_name = php_uname( 'n' );
 					} elseif ( ! empty( $_SERVER['SERVER_NAME'] ) ) {
 						$host_name = $_SERVER['SERVER_NAME'];

--- a/panels/class-debug-bar-deprecated.php
+++ b/panels/class-debug-bar-deprecated.php
@@ -60,9 +60,9 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 	public static function start_logging() {
 		add_action( 'deprecated_function_run', array( __CLASS__, 'deprecated_function_run' ), 10, 3 );
 		add_action( 'deprecated_file_included', array( __CLASS__, 'deprecated_file_included' ), 10, 4 );
-		add_action( 'deprecated_argument_run',  array( __CLASS__, 'deprecated_argument_run' ),  10, 3 );
-		add_action( 'deprecated_hook_run',  array( __CLASS__, 'deprecated_hook_run' ),  10, 4 );
-		add_action( 'deprecated_constructor_run',  array( __CLASS__, 'deprecated_constructor_run' ),  10, 3 );
+		add_action( 'deprecated_argument_run', array( __CLASS__, 'deprecated_argument_run' ), 10, 3 );
+		add_action( 'deprecated_hook_run', array( __CLASS__, 'deprecated_hook_run' ), 10, 4 );
+		add_action( 'deprecated_constructor_run', array( __CLASS__, 'deprecated_constructor_run' ), 10, 3 );
 
 		// Silence E_NOTICE for deprecated usage.
 		foreach ( array( 'function', 'file', 'argument', 'constructor' ) as $item ) {
@@ -78,9 +78,9 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 	public static function stop_logging() {
 		remove_action( 'deprecated_function_run', array( __CLASS__, 'deprecated_function_run' ), 10 );
 		remove_action( 'deprecated_file_included', array( __CLASS__, 'deprecated_file_included' ), 10 );
-		remove_action( 'deprecated_argument_run',  array( __CLASS__, 'deprecated_argument_run' ),  10 );
-		remove_action( 'deprecated_hook_run',  array( __CLASS__, 'deprecated_hook_run' ),  10 );
-		remove_action( 'deprecated_constructor_run',  array( __CLASS__, 'deprecated_constructor_run' ),  10 );
+		remove_action( 'deprecated_argument_run', array( __CLASS__, 'deprecated_argument_run' ), 10 );
+		remove_action( 'deprecated_hook_run', array( __CLASS__, 'deprecated_hook_run' ), 10 );
+		remove_action( 'deprecated_constructor_run', array( __CLASS__, 'deprecated_constructor_run' ), 10 );
 
 		// Don't silence E_NOTICE for deprecated usage.
 		foreach ( array( 'function', 'file', 'argument', 'constructor' ) as $item ) {
@@ -169,7 +169,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			$message = sprintf( __( '%1$s is <strong>deprecated</strong> since version %2$s with no alternative available.', 'debug-bar' ), $function, $version );
 		}
 
-		$key = md5( $location . ':' . $message );
+		$key                                = md5( $location . ':' . $message );
 		self::$deprecated_functions[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, $bt ) );
 
 		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . '  in ' . $location );
@@ -201,7 +201,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			$message = sprintf( __( '%1$s is <strong>deprecated</strong> since version %2$s with no alternative available.', 'debug-bar' ), $file_abs, $version ) . $message;
 		}
 
-		$key = md5( $location . ':' . $message );
+		$key                            = md5( $location . ':' . $message );
 		self::$deprecated_files[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, 4 ) );
 
 		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . '  in ' . $location );
@@ -270,7 +270,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 		if ( ! is_null( $replacement ) ) {
 			$message = sprintf(
 				/* translators: %1$s is a hook name, %2$s a version number, %3$s an alternative hook to use. */
-				__( '%1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.' , 'debug-bar' ),
+				__( '%1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.', 'debug-bar' ),
 				$hook,
 				$version,
 				$replacement
@@ -286,7 +286,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			$message .= ' ' . $hook_message;
 		}
 
-		$key = md5( $location . ':' . $message );
+		$key                            = md5( $location . ':' . $message );
 		self::$deprecated_hooks[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, $bt ) );
 
 		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . '  in ' . $location );
@@ -331,7 +331,7 @@ class Debug_Bar_Deprecated extends Debug_Bar_Panel {
 			);
 		}
 
-		$key = md5( $location . ':' . $message );
+		$key                                   = md5( $location . ':' . $message );
 		self::$deprecated_constructors[ $key ] = array( $location, $message, wp_debug_backtrace_summary( null, $bt ) );
 
 		error_log( 'Deprecation Notice: ' . strip_tags( $message ) . ' in ' . $location );

--- a/panels/class-debug-bar-doing-it-wrong.php
+++ b/panels/class-debug-bar-doing-it-wrong.php
@@ -118,7 +118,7 @@ class Debug_Bar_Doing_It_Wrong extends Debug_Bar_Panel {
 			$version
 		);
 
-		$key = md5( $location . ':' . $message );
+		$key                          = md5( $location . ':' . $message );
 		self::$doing_it_wrong[ $key ] = array( $location, $notice, wp_debug_backtrace_summary( null, $bt ) );
 
 		error_log( 'Doing it wrong Notice: ' . strip_tags( $notice ) . '  in ' . $location );

--- a/panels/class-debug-bar-panel.php
+++ b/panels/class-debug-bar-panel.php
@@ -1,7 +1,7 @@
 <?php
 
 abstract class Debug_Bar_Panel {
-	public $_title = '';
+	public $_title   = '';
 	public $_visible = true;
 
 	public function __construct( $title = '' ) {

--- a/panels/class-debug-bar-queries.php
+++ b/panels/class-debug-bar-queries.php
@@ -32,7 +32,7 @@ class Debug_Bar_Queries extends Debug_Bar_Panel {
 				$out .= '<p>' . sprintf( __( 'There are too many queries to show easily! <a href="%s">Show them anyway</a>', 'debug-bar' ), esc_url( add_query_arg( 'debug_queries', 'true' ) ) ) . '</p>';
 			}
 
-			$out .= '<ol class="wpd-queries">';
+			$out    .= '<ol class="wpd-queries">';
 			$counter = 0;
 
 			foreach ( $wpdb->queries as $q ) {
@@ -50,8 +50,9 @@ class Debug_Bar_Queries extends Debug_Bar_Panel {
 				$debug = str_replace( array( 'do_action, call_user_func_array' ), array( 'do_action' ), $debug );
 				$debug = esc_html( $debug );
 				$query = nl2br( esc_html( $query ) );
+
 				/* translators: %s = duration in milliseconds. */
-				$time  = esc_html( sprintf( __( '%s ms', 'debug-bar' ), number_format_i18n( ( $elapsed * 1000 ), 1 ) ) );
+				$time = esc_html( sprintf( __( '%s ms', 'debug-bar' ), number_format_i18n( ( $elapsed * 1000 ), 1 ) ) );
 
 				$out .= "<li>$query<br/><div class='qdebug'>$debug <span>#$counter ($time)</span></div></li>\n";
 			}
@@ -69,7 +70,7 @@ class Debug_Bar_Queries extends Debug_Bar_Panel {
 			foreach ( $EZSQL_ERROR as $error ) {
 				$query   = nl2br( esc_html( $error['query'] ) );
 				$message = esc_html( $error['error_str'] );
-				$out .= "<li>$query<br/><div class='qdebug'>$message</div></li>\n";
+				$out    .= "<li>$query<br/><div class='qdebug'>$message</div></li>\n";
 			}
 			$out .= '</ol>';
 		}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -37,12 +37,16 @@
 
 		<!-- Bit over-zealous, we're not using the value, just checking whether it's set.
 			 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/737 -->
-		<exclude name="WordPress.CSRF.NonceVerification"/>
+		<exclude name="WordPress.Security.NonceVerification"/>
 	</rule>
+
+	<!-- Set the minimum supported WP version for this plugin for sniffs
+		 checking usage of deprecated WP features. -->
+	<config name="minimum_supported_wp_version" value="3.4"/>
 
 	<!-- Downgrade the XSS sniff to a warning. These issues *do* need to be addressed at some point,
 		 but shouldn't fail the build at this moment. -->
-	<rule ref="WordPress.XSS.EscapeOutput.OutputNotEscaped">
+	<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">
 		<type>warning</type>
 	</rule>
 
@@ -66,27 +70,6 @@
 			<property name="prefixes" type="array" value="debug_bar" />
 		</properties>
 	</rule>
-
-	<!-- Set the minimum supported version for this plugin. -->
-	<rule ref="WordPress.WP.DeprecatedFunctions">
-		<properties>
-			<property name="minimum_supported_version" value="3.4" />
-		</properties>
-	</rule>
-
-	<rule ref="WordPress.WP.DeprecatedClasses">
-		<properties>
-			<property name="minimum_supported_version" value="3.4" />
-		</properties>
-	</rule>
-
-	<!-- To be activated once PR #826 in WPCS has been merged.
-	<rule ref="WordPress.WP.DeprecatedParameter">
-		<properties>
-			<property name="minimum_supported_version" value="3.4" />
-		</properties>
-	</rule>
-	-->
 
 	<!-- Allow the main file to not comply with the codestyle rules.
 		 Changing the filename now, would break recognition of the plugin as active on upgrade. -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -24,6 +24,14 @@
 		<exclude name="PHPCompatibility.PHP.NewFunctionParameters.debug_backtrace_optionsFound"/>
 	</rule>
 
+	<!-- We can ignore these two errors as the referenced file back-fills them if needed. -->
+	<rule ref="PHPCompatibility.PHP.NewConstants.e_deprecatedFound">
+		<exclude-pattern>*/class-debug-bar-php\.php</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.PHP.NewConstants.e_user_deprecatedFound">
+		<exclude-pattern>*/class-debug-bar-php\.php</exclude-pattern>
+	</rule>
+
 	<!--
 		##### WordPress sniffs #####
 		The `WordPress-Extra` ruleset contains the WP Core rules + best practices.


### PR DESCRIPTION
This will allow the build to pass for new PRs.

The Core handbook has been adjusted over the past few months to be stricter about certain previously implied whitespace rules. WPCS has been adjusted to follow suite.